### PR TITLE
Fix dev-java/hdf-java-2.8 so it builds with the hdfview USE flag enabled

### DIFF
--- a/dev-java/hdf-java/hdf-java-2.8.ebuild
+++ b/dev-java/hdf-java/hdf-java-2.8.ebuild
@@ -100,10 +100,11 @@ src_install() {
 		java-pkg_dojar lib/ext/fitsobj.jar
 		java-pkg_dojar lib/jhdfview.jar
 		cat <<-EOF > hdfview
+			#!/bin/sh
 			export CLASSPATH=\$(java-config --classpath hdf-java)
 			\$(java-config --java) \
 				-Xmx1000m \
-				-Djava.library.path=\"\$(java-config --library hdf-java)\" \
+				-Djava.library.path=\$(java-config --library hdf-java) \
 				ncsa.hdf.view.HDFView \
 				-root "${EROOT}" \$*
 		EOF


### PR DESCRIPTION
Also contains a minor HOMEPAGE typo fix.

Version not bumped to r1 because anyone who built 2.8 successfully must have had hdfview disabled, and there's no sense in making them recompile.
