### PR TITLE
Enable cross-compilation of {CBLAS,LAPACK}-reference

### DIFF
--- a/sci-libs/cblas-reference/cblas-reference-20110218.ebuild
+++ b/sci-libs/cblas-reference/cblas-reference-20110218.ebuild
@@ -72,7 +72,7 @@ src_compile() {
 		CFLAGS="${CFLAGS} -fPIC" \
 		CBLIB=../lib/lib${LIBNAME}.a \
 		alllib
-	static_to_shared lib/lib${LIBNAME}.a $(pkg-config --libs blas)
+	static_to_shared lib/lib${LIBNAME}.a $($(tc-getPKG_CONFIG) --libs blas)
 	if use static-libs; then
 		emake clean
 		emake alllib

--- a/sci-libs/lapack-reference/lapack-reference-3.4.1.ebuild
+++ b/sci-libs/lapack-reference/lapack-reference-3.4.1.ebuild
@@ -3,7 +3,7 @@
 # $Header: $
 
 EAPI=4
-inherit eutils fortran-2 cmake-utils alternatives-2
+inherit eutils fortran-2 cmake-utils alternatives-2 toolchain-funcs
 
 MYP=lapack-${PV}
 
@@ -33,7 +33,7 @@ src_configure() {
 	lapack_configure() {
 		local mycmakeargs=(
 			-DUSE_OPTIMIZED_BLAS=ON
-			-DBLAS_LIBRARIES="$(pkg-config --libs blas)"
+			-DBLAS_LIBRARIES="$($(tc-getPKG_CONFIG) --libs blas)"
 			$(cmake-utils_use_build test TESTING)
 			$(cmake-utils_use_use xblas XBLAS)
 			$@


### PR DESCRIPTION
I just changed the call of pkg-config to $(tc-getPKG_CONFIG)
