### PR TITLE
sci-physics/LoopTools: shared library generation and dependency on virtu...

### DIFF
--- a/sci-physics/LoopTools/ChangeLog
+++ b/sci-physics/LoopTools/ChangeLog
@@ -2,6 +2,13 @@
 # Copyright 1999-2012 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+*LoopTools-2.7-r1 (28 Aug 2012)
+
+  28 Aug 2012; Jauhien Piatlicki (jauhien) <piatlicki@gmail.com>
+  -LoopTools-2.7.ebuild, +LoopTools-2.7-r1.ebuild,
+  files/LoopTools-2.7-makefile.patch:
+  shared library generation and dependency on virtual/fortran added
+
 *LoopTools-2.7 (05 Jul 2012)
 
   05 Jul 2012; Jauhien Piatlicki (jauhien) piatlicki@gmail.com

--- a/sci-physics/LoopTools/LoopTools-2.7-r1.ebuild
+++ b/sci-physics/LoopTools/LoopTools-2.7-r1.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=4
 
-inherit eutils
+inherit eutils fortran-2
 
 DESCRIPTION="A package for evaluation of scalar and tensor one-loop integrals"
 HOMEPAGE="http://www.feynarts.de/looptools"
@@ -16,9 +16,10 @@ SLOT="0"
 KEYWORDS="~x86"
 IUSE=""
 
-DEPEND=""
-RDEPEND=""
+DEPEND="virtual/fortran"
+RDEPEND="${DEPEND}"
 
 src_prepare() {
 	epatch "${FILESDIR}/${P}-makefile.patch"
+	export VER="${PV}"
 }

--- a/sci-physics/LoopTools/files/LoopTools-2.7-makefile.patch
+++ b/sci-physics/LoopTools/files/LoopTools-2.7-makefile.patch
@@ -1,6 +1,6 @@
 --- makefile.in
 +++ makefile.in
-@@ -1,8 +1,8 @@
+@@ -1,14 +1,17 @@
  BLD = build$(QUADSUFFIX)
  
 -LIBDIR = $(PREFIX)/lib$(LIBDIRSUFFIX)
@@ -12,11 +12,47 @@
  
  LIB = libooptools$(QUADSUFFIX).a
  FE = lt$(QUADSUFFIX)$(EXE)
-@@ -38,13 +38,12 @@
+ MFE = LoopTools$(QUADSUFFIX)$(EXE)
+ INCLUDE = $(BLD)/looptools.h $(BLD)/clooptools.h
+ 
++LIBRARY=libooptools.so
++REALNAME=$(LIBRARY).$(VER)
++
+ ARGS = $(PARALLEL) \
+   LIB="$(LIB)" \
+   FE="$(FE)" \
+@@ -16,12 +19,12 @@
+   EXE="$(EXE)" \
+   DEF="$(DEF)" \
+   NOUNDERSCORE="$(NOUNDERSCORE)" \
+-  XFC="$(FC$(QUADSUFFIX)) $(FFLAGS) $(FFLAGS-quad) -I." \
++  XFC="$(FC$(QUADSUFFIX)) $(FFLAGS) $(FFLAGS-quad) -I. -fPIC" \
+   F90="$(F90)" \
+   CC="$(CC)" \
+-  CFLAGS="$(CFLAGS) $(CFLAGS-quad)" \
++  CFLAGS="$(CFLAGS) $(CFLAGS-quad) -fPIC" \
+   CXX="$(CXX)" \
+-  CXXFLAGS="$(CXXFLAGS)" \
++  CXXFLAGS="$(CXXFLAGS) -fPIC" \
+   ML="$(ML)" \
+   MCC="$(MCC)" \
+   MCFLAGS="$(MCFLAGS)" \
+@@ -31,20 +34,22 @@
+   DLLTOOL="$(DLLTOOL)" \
+   LDFLAGS="$(LDFLAGS)" \
+   LIBPATH="$(LIBPATH)" \
+-  OBJS-quad="$(OBJS-quad)"
++  OBJS-quad="$(OBJS-quad)" \
++  REALNAME="$(REALNAME)"
+ 
+ 
+-default all lib frontend mma: force
++default all lib solib frontend mma: force
  	cd $(BLD) && $(MAKE) $(ARGS) $@
  
- install: lib frontend
+-install: lib frontend
 -	-mkdir $(PREFIX)
++install: lib solib frontend
 +	-mkdir $(DESTDIR)$(PREFIX)
  	-mkdir $(LIBDIR) $(BINDIR) $(INCLUDEDIR)
  	cp -p $(BLD)/$(LIB) $(LIBDIR)
@@ -25,5 +61,36 @@
  	cp -p $(BLD)/fcc $(BLD)/$(FE) $(BINDIR)
 -	test ! -f $(BLD)/$(MFE) || { strip $(BLD)/$(MFE) ; cp -p $(BLD)/$(MFE) $(BINDIR); }
 +	test ! -f $(BLD)/$(MFE) || { cp -p $(BLD)/$(MFE) $(BINDIR); }
++	cp -p $(BLD)/$(REALNAME) $(LIBDIR)
++	cd $(LIBDIR) && ln -s $(REALNAME) $(LIBRARY)
  
  force: $(BLD)/timestamp
+ 
+--- src/makefile
++++ src/makefile
+@@ -1,6 +1,6 @@
+-default: frontend mma$(ML)
++default: frontend mma$(ML) solib
+ 
+-all: frontend mma1
++all: frontend mma1 solib
+ 
+ frontend: lib $(FE)
+ 
+@@ -8,6 +8,7 @@
+ 
+ mma0 lib: $(LIB) clooptools.h fcc
+ 
++solib: $(REALNAME) fcc
+ 
+ .SUFFIXES:
+ 
+@@ -247,6 +248,8 @@
+ 	$(AR) cru $(LIB) $?
+ 	-$(RANLIB) $(LIB)
+ 
++$(REALNAME): $(OBJS)
++	$(CC) $(CFLAGS) $(LDFLAGS) -shared -o $@ $?
+ 
+ $(FE): lt.F $(LTINC) $(LIB)
+ 	$(XFC) -o $(FE) lt.F $(LIB)


### PR DESCRIPTION
Dependency on virtual/fortran added, as package is compiled with fortran compiler.
Generating of shared library added, as it can be needed for someone, at least it is needed for Bug 433060 (https://bugs.gentoo.org/show_bug.cgi?id=433060)

(Portage version: 2.2.0_alpha121/git/Linux i686, unsigned Manifest commit)
