### PR TITLE
dev-java/netcdf: Add the netCDF licence (which is *not* MIT)

### DIFF
--- a/dev-java/netcdf/ChangeLog
+++ b/dev-java/netcdf/ChangeLog
@@ -2,6 +2,11 @@
 # Copyright 1999-2012 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+*netcdf-4.2 (18 Nov 2012)
+
+  18 Nov 2012; W. Trevor King <wking@drexel.edu> netcdf-4.2.ebuild:
+  Fix license (the NetCDF license is neither LGPL or MIT)
+
 *netcdf-4.2 (14 May 2012)
 
   14 May 2012; Sébastien Fabbro <bicatali@gentoo.org> +netcdf-4.2.ebuild,

--- a/dev-java/netcdf/netcdf-4.2.ebuild
+++ b/dev-java/netcdf/netcdf-4.2.ebuild
@@ -10,7 +10,7 @@ DESCRIPTION="Java Common Data Model (CDM) interface to to netCDF files"
 HOMEPAGE="http://www.unidata.ucar.edu/software/netcdf-java/"
 SRC_URI="ftp://ftp.unidata.ucar.edu/pub/${PN}-java/v${PV}/ncSrc-${PV}.zip"
 
-LICENSE="LGPL-2 MIT"
+LICENSE="netCDF"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE=""

--- a/licenses/netCDF
+++ b/licenses/netCDF
@@ -1,0 +1,31 @@
+Copyright 1993-2012 University Corporation for Atmospheric Research/Unidata
+
+Portions of this software were developed by the Unidata Program at the
+University Corporation for Atmospheric Research.
+
+Access and use of this software shall impose the following obligations
+and understandings on the user. The user is granted the right, without
+any fee or cost, to use, copy, modify, alter, enhance and distribute
+this software, and any derivative works thereof, and its supporting
+documentation for any purpose whatsoever, provided that this entire
+notice appears in all copies of the software, derivative works and
+supporting documentation. Further, UCAR requests that the user credit
+UCAR/Unidata in any publications that result from the use of this
+software or in any product that includes this software, although this
+is not an obligation. The names UCAR and/or Unidata, however, may not
+be used in any advertising or publicity to endorse or promote any
+products or commercial entity unless specific written permission is
+obtained from UCAR/Unidata. The user also understands that
+UCAR/Unidata is not obligated to provide the user with any support,
+consulting, training or assistance of any kind with regard to the use,
+operation and performance of this software nor to provide the user
+with any updates, revisions, new versions or "bug fixes."
+
+THIS SOFTWARE IS PROVIDED BY UCAR/UNIDATA "AS IS" AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL UCAR/UNIDATA BE LIABLE FOR ANY SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+WITH THE ACCESS, USE OR PERFORMANCE OF THIS SOFTWARE.


### PR DESCRIPTION
I'm not sure why the license was changed when this ebuild was imported
from my overlay, but NetCDF deserves its own entry under licenses/

From http://www.unidata.ucar.edu/software/netcdf-java/documentation.htm:

> The library is freely available and the source code is released
> under the (MIT-style) netCDF C library license. Previous versions
> use the GNU Lesser General Public License (LGPL).

The [license text](http://www.unidata.ucar.edu/software/netcdf/copyright.html) has several important deviations from MIT, for
example:
- netCDF does not explicitly grant the right to sublicense and/or sell
  copies, while MIT does.

There are also a number of other changes, involving legalese that I
don't understand.  However, I imagine the UCAR/Unidata lawyers made
the deviations from the MIT license intentionally, and Gentoo users
should be able to easily see what they are getting into by using this
package.
