### PR TITLE
Live ebuild for pybrain

### DIFF
--- a/sci-biology/pybrain/metadata.xml
+++ b/sci-biology/pybrain/metadata.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<!--
+$Header: /var/cvsroot/gentoo-x86/skel.metadata.xml,v 1.21 2012/02/07 00:03:15 idl0r Exp $
+
+This is the example metadata file.
+The root element of this file is <pkgmetadata>. Within this element a
+number of subelements are allowed: herd, maintainer, and
+longdescription. herd is a required subelement.
+
+For a full description look at:
+http://www.gentoo.org/proj/en/devrel/handbook/handbook.xml?part=2&chap=4
+
+
+Before committing, please remove the comments from this file. They are
+not relevant for general metadata.xml files.
+-->
+<pkgmetadata>
+	<herd>sci</herd>
+<maintainer>
+	<email>@gentoo.org</email>
+<!--  <description>Description of the maintainership</description> -->
+</maintainer>
+<!-- <longdescription>Long description of the package</longdescription> -->
+<!--
+<use>
+	<flag name="flag">Description of how USE='flag' affects this package</flag>
+	<flag name="userland_GNU">Description of how USERLAND='GNU' affects this
+		package</flag>
+	<flag name="aspell">Uses <pkg>app-text/aspell</pkg> for spell checking.
+		Requires an installed dictionary from <cat>app-dicts</cat></flag>
+</use>
+-->
+</pkgmetadata>

--- a/sci-biology/pybrain/pybrain-9999.ebuild
+++ b/sci-biology/pybrain/pybrain-9999.ebuild
@@ -14,12 +14,12 @@ inherit eutils distutils git-2
 DESCRIPTION="The Python Machine Learning Library"
 HOMEPAGE="http://pybrain.org/"
 EGIT_REPO_URI="git://github.com/pybrain/pybrain.git"
+
 LICENSE="BSD"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 IUSE="test"
 
 RDEPEND="sci-libs/scipy"
-
 DEPEND="dev-python/setuptools
 	test? ( ${RDEPEND} )"


### PR DESCRIPTION
Added a live ebuild for the python machnie learning library. Put it in sci-bio for lack of other options.
