### PR TITLE
Run permissions for the packages GUI script

### DIFF
--- a/sci-biology/psychopy/psychopy-1.75.01.ebuild
+++ b/sci-biology/psychopy/psychopy-1.75.01.ebuild
@@ -10,7 +10,7 @@ SUPPORT_PYTHON_ABIS="1"
 RESTRICT_PYTHON_ABIS="3.* *-jython *-pypy-*"
 DISTUTILS_SRC_TEST="py.test"
 
-inherit distutils-r1 eutils
+inherit distutils-r1 gnome2-utils eutils
 
 MY_P="PsychoPy-${PV}"
 
@@ -49,5 +49,8 @@ python_install_all() {
 }
 
 pkg_postinst() {
+	gnome2_icon_cache_update
+}
+pkg_postrm() {
 	gnome2_icon_cache_update
 }

--- a/sci-biology/psychopy/psychopy-9999.ebuild
+++ b/sci-biology/psychopy/psychopy-9999.ebuild
@@ -5,7 +5,7 @@
 EAPI="5"
 PYTHON_COMPAT=( python2_7 )
 
-inherit eutils distutils-r1 git-2
+inherit eutils gnome2-eutils distutils-r1 git-2
 
 DESCRIPTION="Python experiemntal psychology toolkit"
 HOMEPAGE="http://www.psychopy.org/"
@@ -35,5 +35,8 @@ python_install_all() {
 }
 
 pkg_postinst() {
+	gnome2_icon_cache_update
+}
+pkg_postrm() {
 	gnome2_icon_cache_update
 }


### PR DESCRIPTION
Hello, this package had a gui launcher (which I was unaware of since I'm only using its functions in scripts) I submitted the modified ebuilds which make it executable. It would be great if you could tell me how I can make sure it also gets a launcher binding, though you can just pull as such if not. It's an improvement anyway!
