### PR TITLE
Stop duplicating ${myconf}

### DIFF
--- a/sys-cluster/lustre/lustre-9999.ebuild
+++ b/sys-cluster/lustre/lustre-9999.ebuild
@@ -101,9 +101,9 @@ src_configure() {
 	local myconf
 	if use server; then
 		SPL_PATH=$(basename $(echo "${EROOT}usr/src/spl-"*)) \
-			myconf+="${myconf} --with-spl=\"${EROOT}usr/src/${SPL_PATH}\""
+			myconf="${myconf} --with-spl=\"${EROOT}usr/src/${SPL_PATH}\""
 		ZFS_PATH=$(basename $(echo "${EROOT}usr/src/zfs-"*)) \
-			myconf+="${myconf} --with-zfs=\"${EROOT}usr/src/${ZFS_PATH}\""
+			myconf="${myconf} --with-zfs=\"${EROOT}usr/src/${ZFS_PATH}\""
 	fi
 	econf \
 		${myconf} \


### PR DESCRIPTION
Doing myconf+="${myconf} ..." in the ebuild caused us to append not only
our addition to ${myconfig}, but also to prepend the contents of
${myconf} to itself. This resulted in configure script lines that looked
something like this:

./configure ... --with-spl="/usr/src/spl-0.6.1" --with-spl="/usr/src/spl-0.6.1"
--with-zfs="/usr/src/zfs-0.6.1" ...

We switch to myconf="${myconf} ..." to correct that.

Signed-off-by: Richard Yao ryao@gentoo.org
