### PR TITLE
Changes to the patch files to make the shiftx2 package working again.

### DIFF
--- a/sci-chemistry/shiftx2/ChangeLog
+++ b/sci-chemistry/shiftx2/ChangeLog
@@ -2,7 +2,13 @@
 # Copyright 1999-2013 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  21 Jun 2013; johann@j-schmitz.net files/shiftx2-1.07_p20120106-java.patch,
+  files/shiftx2-1.07_p20120106-system.patch:
+  Completly removed the directory check in the java source (we have everything
+  under control in gentoo). Removed the .py extension from the -system.patch to
+  make that part working again (it's installed without extensions to
+  /usr/bin/!).
+
   16 Jun 2013; Justin Lecher <jlec@gentoo.org> shiftx2-1.07_p20120106.ebuild,
   metadata.xml:
   Respect FLAGS
-

--- a/sci-chemistry/shiftx2/files/shiftx2-1.07_p20120106-java.patch
+++ b/sci-chemistry/shiftx2/files/shiftx2-1.07_p20120106-java.patch
@@ -182,13 +182,46 @@ index 505a3f6..920f420 100755
      // Loading only one time, that's why these are here 
      static RandomCoil rcoil = new RandomCoil();
      static LimitedCShift chkcshift = new LimitedCShift();
-@@ -140,8 +140,7 @@ public class ShiftXp {
+@@ -41,7 +41,7 @@ public class ShiftXp {
+         buf.append("Detail information: http://www.shiftx2.ca or http://redpoll.pharmacy.ualberta.ca\n");
+         buf.append("--------------------------------------------------------------------------------\n\n");
  
-         // check execute directory 
-         // 2011.08.31 changed shiftx2_main.py --> shiftx2.py
+-        buf.append("SYNOPSIS\n\t java -Xmx1500m -cp <SHIFTX+ dir>/bin:<SHIFTX+ dir>/lib/weka.jar ShiftXp [options]\n");
++        buf.append("SYNOPSIS\n\t jshiftx2 [options]\n");
+ 
+         buf.append("OPTIONS:\n");
+         buf.append("\t -i [<directory/> infile.pdb | ALLPDB]\n");
+@@ -54,10 +54,10 @@ public class ShiftXp {
+         buf.append("\t -temp <number>        Temperature, default=298\n");
+         buf.append("\t -d [TRUE | FALSE]  Deuterated pdb, default=FALSE \n"); 
+         buf.append("\t -r [TRUE | FALSE]  Print randon coild shift (only for CSV format), default=FALSE \n"); 
+-        buf.append("\t -dir <SHIFTX+ directory>  The installed directory of SHIFTX+/SHIFTX2\n\n");
++//        buf.append("\t -dir <SHIFTX+ directory>  The installed directory of SHIFTX+/SHIFTX2\n\n");
+ 
+         buf.append("EXAMPLE:\n");
+-        buf.append("\t java -Xmx1500m -cp ~/shiftx2/bin:~/shiftx2/lib/weka.jar ShiftXp -i 1ubq.pdb\n\n");
++        buf.append("\t jshiftx2 -i 1ubq.pdb\n\n");
+         buf.append("\n");
+ 
+         System.out.println( buf );
+@@ -138,20 +138,6 @@ public class ShiftXp {
+            }     
+         }
+ 
+-        // check execute directory 
+-        // 2011.08.31 changed shiftx2_main.py --> shiftx2.py
 -        if ( !( new File( SHIFTX2_DIR + "/shiftx2.py").exists() 
 -             &&  new File(SHIFTX2_DIR + "/lib/weka.jar").exists() )  )  {
-+        if (!new File(SHIFTX2_DIR + "/shiftx2.py").exists()) {
- 
+-
+-           System.err.println("\n********************************************************************************");
+-           System.err.println("[Error]\t Required: When the SHIFTX2 execute on other directory,\n"
+-                             +"\t it should be set as a parameter. Use '-dir' option.");
+-           System.err.println("> Current directory: "+System.getProperty("user.dir"));
+-           System.err.println("********************************************************************************\n");
+-
+-           usage();
+-        }
+-
+         if ( inPDBFile == null || inPDBFile.length() < 1)  {
             System.err.println("\n********************************************************************************");
-            System.err.println("[Error]\t Required: When the SHIFTX2 execute on other directory,\n"
+            System.err.println("[Error] Required: There is no input PDB filename.");

--- a/sci-chemistry/shiftx2/files/shiftx2-1.07_p20120106-system.patch
+++ b/sci-chemistry/shiftx2/files/shiftx2-1.07_p20120106-system.patch
@@ -81,7 +81,7 @@ index 0a171c8..72ecbfe 100755
              sys.path.append(SHIFTX2ROOT+"/shifty3")
              os.chdir(SHIFTX2ROOT+"/shifty3")
 -            shifty_cmd = "python shifty3.py -i " + \
-+            shifty_cmd = "shifty3.py -i " + \
++            shifty_cmd = "shifty3 -i " + \
                  infile + " -o " + infile + ".shifty -c 40 "
              if DEUTERATED:
                  shifty_cmd = shifty_cmd + " -d"
@@ -125,7 +125,7 @@ index 0a171c8..72ecbfe 100755
          sys.path.append( SHIFTX2ROOT + "/shifty3")
          os.chdir(SHIFTX2ROOT + "/shifty3")
 -        shifty_cmd = "python shifty3.py -i " + infile + \
-+        shifty_cmd = "shifty3.py -i " + infile + \
++        shifty_cmd = "shifty3 -i " + infile + \
              " -o " + infile + ".shifty -c 40 "
          if DEUTERATED:
              shifty_cmd = shifty_cmd + " -d"
@@ -176,7 +176,7 @@ index 0a171c8..72ecbfe 100755
          sys.path.append(SHIFTX2ROOT + "/shifty3")
          os.chdir(SHIFTX2ROOT +"/shifty3")
 -        shifty_cmd = "python shifty3.py -i " + inputfile + " -o " + sy_outfile + " -c 40 "
-+        shifty_cmd = "shifty3.py -i " + inputfile + " -o " + sy_outfile + " -c 40 "
++        shifty_cmd = "shifty3 -i " + inputfile + " -o " + sy_outfile + " -c 40 "
          if DEUTERATED:
              shifty_cmd = shifty_cmd + " -d"
          if VERBOSE:


### PR DESCRIPTION
Completly removed the directory check in the java source (we have everything under control in gentoo).

Removed the .py extension from the -system.patch to make that part working again (it's installed without extensions to /usr/bin/!).

Package-Manager: portage-2.1.12.2
