### PR TITLE
dev-lang/julia: Use git-2.eclass’ submodule support.

### DIFF
--- a/dev-lang/julia/ChangeLog
+++ b/dev-lang/julia/ChangeLog
@@ -2,6 +2,9 @@
 # Copyright 1999-2013 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  14 Jul 2013; James Cloos <cloos@jhcloos.com> julia-9999.ebuild:
+  Julia uses submodules, so set EGIT_HAS_SUBMODULES=yes
+  
   14 Jun 2013; Justin Lecher <jlec@gentoo.org> julia-9999.ebuild, metadata.xml:
   Drop KEYWORDS of live ebuilds
 

--- a/dev-lang/julia/julia-9999.ebuild
+++ b/dev-lang/julia/julia-9999.ebuild
@@ -5,6 +5,7 @@
 EAPI=5
 
 EGIT_REPO_URI="git://github.com/JuliaLang/julia.git"
+EGIT_HAS_SUBMODULES=yes
 
 inherit git-2 elisp-common eutils multilib
 


### PR DESCRIPTION
Using the eclass’ submodule support permits it to store the submodule
repositories in egit-src.  Otherwise, julia’s make has to re-clone each
of the sub-repos from scratch every emerge.

Signed-off-by: James Cloos cloos@jhcloos.com
