### PR TITLE
Update root-9999.ebuild

### DIFF
--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -82,7 +82,7 @@ CDEPEND="
 	graphviz? ( media-gfx/graphviz )
 	kerberos? ( virtual/krb5 )
 	ldap? ( net-nds/openldap )
-	llvm? ( =sys-devel/clang-9999 =sys-devel/llvm-9999 )
+	llvm? ( >=sys-devel/clang-9999 =sys-devel/llvm-9999 )
 	math? ( sci-libs/gsl sci-mathematics/unuran mpi? ( virtual/mpi ) )
 	mysql? ( virtual/mysql )
 	odbc? ( || ( dev-db/libiodbc dev-db/unixODBC ) )


### PR DESCRIPTION
Update root-9999 to require >=clang-9999.
When installing both llvm and clang from git, the correct version of clang is now 9999-r100.
I prefer not to put =clang-9999-r100 so that it won't break if they change it again.
~clang-9999 is a possible (and suitable) alternative.
