### PR TITLE
Fix broken minimum version check in scilab-5.3.3

### DIFF
--- a/sci-mathematics/scilab/files/scilab-5.3.3-java-version-check.patch
+++ b/sci-mathematics/scilab/files/scilab-5.3.3-java-version-check.patch
@@ -1,0 +1,23 @@
+diff -Naurp scilab-5.3.3-r1-orig/m4/java-thirdparty.m4 scilab-5.3.3-r1/m4/java-thirdparty.m4
+--- scilab-5.3.3-r1-orig/m4/java-thirdparty.m4	2013-01-07 14:55:58.516374556 +0100
++++ scilab-5.3.3-r1/m4/java-thirdparty.m4	2013-01-07 16:19:21.256370075 +0100
+@@ -38,9 +38,16 @@ AC_DEFUN([AC_JAVA_CHECK_VERSION_PACKAGE]
+    AC_JAVA_TRY_COMPILE($2, [String minVersion="$4";
+                             $6
+                             System.out.println($5);
+-                                  if (minVersion.compareTo($5) > 0) {
+-                                   System.exit(-1);
+-                                } ]
++                            String[] minV = minVersion.split("\\.");
++                            String[] curV = $5.split("\\.");
++                            for (int i=0; i<Math.max(minV.length,curV.length); i++) {
++                                int mE = i<minV.length ? Integer.parseInt(minV[i]) : 0;
++                                int cE = i<curV.length ? Integer.parseInt(curV[i]) : 0;
++                                if (mE < cE)
++                                    break;
++                                if (mE > cE)
++                                    System.exit(-1);
++                            } ]
+                             , "yes", echo "yes" , AC_MSG_ERROR([Wrong version of $1. Expected at least $4. Found $STDOUT]))
+    else
+    AC_JAVA_TRY_COMPILE($2, [String minVersion="$4";

--- a/sci-mathematics/scilab/scilab-5.3.3-r2.ebuild
+++ b/sci-mathematics/scilab/scilab-5.3.3-r2.ebuild
@@ -125,7 +125,8 @@ src_prepare() {
 		"${FILESDIR}"/${P}-no-xcos-deps.patch \
 		"${FILESDIR}"/${P}-javadoc-utf8.patch \
 		"${FILESDIR}"/${P}-fix-random-runtime-failures.patch \
-		"${FILESDIR}"/${P}-gui-no-xcos.patch
+		"${FILESDIR}"/${P}-gui-no-xcos.patch \
+		"${FILESDIR}"/${P}-java-version-check.patch
 
 	# need serious as-needed work (inter-dependencies among modules)
 	#	"${FILESDIR}"/${P}-as-needed.patch \


### PR DESCRIPTION
Check compares version strings lexicographically, which does not work
e.g. returns "4.2.8" > "4.2.10".
Instead, all numbers composing the version number should be compared one
by one.

This occurs in particular with hdf5-1.8.10 (present on the system) vs hdf5-1.8.4 (minimum required version).
