### PR TITLE
Fix false positive from revdep-rebuild for scilab-5.4.1

### DIFF
--- a/sci-mathematics/scilab/scilab-5.4.1.ebuild
+++ b/sci-mathematics/scilab/scilab-5.4.1.ebuild
@@ -228,7 +228,8 @@ src_install() {
 	prune_libtool_files --all
 	rm -rf "${D}"/usr/share/scilab/modules/*/tests ||die
 	use bash-completion && dobashcomp "${FILESDIR}"/${PN}.bash_completion
-	echo "SEARCH_DIRS_MASK=${EPREFIX}/usr/$(get_libdir)/scilab" \
+	echo "LD_LIBRARY_MASK=libverify.so
+SEARCH_DIRS_MASK=${EPREFIX}/usr/$(get_libdir)/scilab" \
 		> 50-"${PN}"
 	insinto /etc/revdep-rebuild && doins "50-${PN}"
 }


### PR DESCRIPTION
The scilab-bin binary links against some Java libraries that are not
present in the regular path, hence resulting in revdep-rebuild reporting
them as missing and triggering a rebuild. However these are false
positive since the scilab script sets the right path before invoking
scilab-bin.

In particular, libverify.so is part of the JRE and has to be masked.
