### PR TITLE
sci-physics/thepeg, sci-physics/herwig++: ~amd64 keyword added

### DIFF
--- a/sci-physics/herwig++/herwig++-2.6.3.ebuild
+++ b/sci-physics/herwig++/herwig++-2.6.3.ebuild
@@ -15,7 +15,7 @@ SRC_URI="http://www.hepforge.org/archive/herwig/${MYP}.tar.bz2"
 LICENSE="GPL-2"
 
 SLOT="0"
-KEYWORDS="~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="fastjet"
 
 DEPEND="dev-libs/boost
@@ -23,7 +23,7 @@ DEPEND="dev-libs/boost
 	sci-libs/gsl
 	sci-physics/LoopTools
 	dev-lang/perl
-	sci-physics/thepeg
+	=sci-physics/thepeg-1.8.3
 	fastjet? ( sci-physics/fastjet )"
 RDEPEND="${DEPEND}"
 

--- a/sci-physics/thepeg/thepeg-1.8.3.ebuild
+++ b/sci-physics/thepeg/thepeg-1.8.3.ebuild
@@ -19,7 +19,7 @@ SRC_URI="http://www.hepforge.org/archive/thepeg/${MYP}.tar.bz2
 LICENSE="GPL-2"
 
 SLOT="0"
-KEYWORDS="~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE="emacs hepmc java lhapdf test zlib"
 
 RDEPEND="sci-libs/gsl


### PR DESCRIPTION
sci-physics/thepeg, sci-physics/herwig++: ~amd64 keyword added, herwig++ depend on the right thepeg version
