### PR TITLE
sci-physics/LoopTools: ~amd64 keyword added, EAPI=5

### DIFF
--- a/sci-physics/LoopTools/LoopTools-2.8.ebuild
+++ b/sci-physics/LoopTools/LoopTools-2.8.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI=4
+EAPI=5
 
 inherit eutils fortran-2
 
@@ -13,7 +13,7 @@ SRC_URI="http://dev.gentoo.org/~jlec/distfiles/${P}.tar.gz"
 LICENSE="LGPL-3"
 
 SLOT="0"
-KEYWORDS="~x86"
+KEYWORDS="~amd64 ~x86"
 IUSE=""
 
 DEPEND="virtual/fortran"


### PR DESCRIPTION
I've forgotten to add ~amd64 keyword to this package, so fixing it.
