### PR TITLE
sci-libs/trilinos: Fix project config directory; version bump

### DIFF
--- a/sci-libs/trilinos/files/trilinos-11.2.3-fix-install-paths.patch
+++ b/sci-libs/trilinos/files/trilinos-11.2.3-fix-install-paths.patch
@@ -1,0 +1,62 @@
+   IF ("${${PROJECT_NAME}_INSTALL_LIBRARIES_AND_HEADERS_DEFAULT}" STREQUAL "")
+     # Assume the TriBITS project wants to install headers and libraries by default
+--- a/cmake/tribits/package_arch/TribitsPackageWritePackageConfig.cmake	2012-11-12 14:58:00.000000000 +0100
++++ b/cmake/tribits/package_arch/TribitsPackageWritePackageConfig.cmake	2012-11-12 14:42:47.000000000 +0100
+@@ -267,8 +267,8 @@
+   # directories using the installed config file. This is to deal with
+   # installers that allow relocation of the install tree at *install*
+   # time.
+-  SET(LIBRARY_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_LIB_DIR}")
+-  SET(INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
++  SET(LIBRARY_DIRS "${${PROJECT_NAME}_INSTALL_LIB_DIR}")
++  SET(INCLUDE_DIRS "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
+ 
+   # Custom code in configuration file.
+   SET(PACKAGE_CONFIG_CODE "")
+@@ -297,7 +297,7 @@
+ 
+   INSTALL(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PACKAGE_NAME}Config_install.cmake
+-    DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PACKAGE_NAME}"
++    DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PACKAGE_NAME}"
+     RENAME ${PACKAGE_NAME}Config.cmake
+   )
+ 
+@@ -477,8 +477,8 @@
+   # directories using the installed config file. This is to deal with
+   # installers that allow relocation of the install tree at *install*
+   # time.
+-  SET(${PROJECT_NAME}_CONFIG_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
+-  SET(${PROJECT_NAME}_CONFIG_LIBRARY_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_LIB_DIR}")
++  SET(${PROJECT_NAME}_CONFIG_INCLUDE_DIRS "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
++  SET(${PROJECT_NAME}_CONFIG_LIBRARY_DIRS "${${PROJECT_NAME}_INSTALL_LIB_DIR}")
+ 
+   # Write the specification of the rpath if necessary. This is only needed if we're building shared libraries. 
+   IF(BUILD_SHARED_LIBS)
+@@ -493,7 +493,7 @@
+   IF(HAS_INSTALL_TARGETS)
+     INSTALL(
+       EXPORT ${PROJECT_NAME}
+-      DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++      DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+       FILE ${PROJECT_NAME}Targets.cmake
+       )
+     # Import the targets in applications.
+@@ -519,7 +519,7 @@
+ 
+   INSTALL(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config_install.cmake
+-    DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++    DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+     RENAME ${PROJECT_NAME}Config.cmake
+   )
+   
+@@ -562,7 +562,7 @@
+ 
+   INSTALL(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+-    DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++    DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+   )
+ 
+ ENDFUNCTION()

--- a/sci-libs/trilinos/files/trilinos-11.4.2-fix-install-paths.patch
+++ b/sci-libs/trilinos/files/trilinos-11.4.2-fix-install-paths.patch
@@ -1,0 +1,60 @@
+--- a/cmake/tribits/package_arch/TribitsWriteClientExportFiles.cmake 2012-11-12 14:58:00.000000000 +0100
++++ b/cmake/tribits/package_arch/TribitsWriteClientExportFiles.cmake 2012-11-12 14:42:47.000000000 +0100
+@@ -478,8 +478,8 @@
+   # directories using the installed config file. This is to deal with
+   # installers that allow relocation of the install tree at *install*
+   # time.
+-  SET(FULL_LIBRARY_DIRS_SET "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_LIB_DIR}")
+-  SET(FULL_INCLUDE_DIRS_SET "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
++  SET(FULL_LIBRARY_DIRS_SET "${${PROJECT_NAME}_INSTALL_LIB_DIR}")
++  SET(FULL_INCLUDE_DIRS_SET "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
+ 
+   # Custom code in configuration file.
+   SET(PACKAGE_CONFIG_CODE "")
+@@ -548,7 +548,7 @@
+   IF (${PROJECT_NAME}_ENABLE_INSTALL_CMAKE_CONFIG_FILES)
+     INSTALL(
+       FILES ${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${PACKAGE_NAME}Config_install.cmake
+-      DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PACKAGE_NAME}"
++      DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PACKAGE_NAME}"
+       RENAME ${PACKAGE_NAME}Config.cmake
+       )
+ 
+@@ -766,8 +766,8 @@
+   # directories using the installed config file. This is to deal with
+   # installers that allow relocation of the install tree at *install*
+   # time.
+-  SET(${PROJECT_NAME}_CONFIG_INCLUDE_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
+-  SET(${PROJECT_NAME}_CONFIG_LIBRARY_DIRS "\${CMAKE_CURRENT_LIST_DIR}/../../../${${PROJECT_NAME}_INSTALL_LIB_DIR}")
++  SET(${PROJECT_NAME}_CONFIG_INCLUDE_DIRS "${${PROJECT_NAME}_INSTALL_INCLUDE_DIR}")
++  SET(${PROJECT_NAME}_CONFIG_LIBRARY_DIRS "${${PROJECT_NAME}_INSTALL_LIB_DIR}")
+ 
+   # Write the specification of the rpath if necessary. This is only needed if we're building shared libraries.
+   IF(BUILD_SHARED_LIBS)
+@@ -782,7 +782,7 @@
+   IF(HAS_INSTALL_TARGETS)
+     INSTALL(
+       EXPORT ${PROJECT_NAME}
+-      DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++      DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+       FILE ${PROJECT_NAME}Targets.cmake
+       )
+     # Import the targets in applications.
+@@ -809,7 +809,7 @@
+ 
+     INSTALL(
+       FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config_install.cmake
+-      DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++      DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+       RENAME ${PROJECT_NAME}Config.cmake
+       )
+   ENDIF()
+@@ -853,7 +853,7 @@
+ 
+   INSTALL(
+     FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+-    DESTINATION "${${PROJECT_NAME}_INSTALL_LIB_DIR}/cmake/${PROJECT_NAME}"
++    DESTINATION "${${PROJECT_NAME}_INSTALL_CONFIG_DIR}/${PROJECT_NAME}"
+   )
+ 
+ ENDFUNCTION()

--- a/sci-libs/trilinos/trilinos-11.2.3-r1.ebuild
+++ b/sci-libs/trilinos/trilinos-11.2.3-r1.ebuild
@@ -1,0 +1,1 @@
+trilinos-11.4.2.ebuild

--- a/sci-libs/trilinos/trilinos-11.4.2.ebuild
+++ b/sci-libs/trilinos/trilinos-11.4.2.ebuild
@@ -81,6 +81,10 @@ trilinos_enable() {
 	cmake-utils_use $1 TPL_ENABLE_${2:-${1^^}}
 }
 
+src_prepare() {
+	epatch "${FILESDIR}"/${P}-fix-install-paths.patch
+}
+
 src_configure() {
 
 	local mycmakeargs=(
@@ -89,6 +93,7 @@ src_configure() {
 		-DTrilinos_ENABLE_ALL_PACKAGES=ON
 		-DTrilinos_INSTALL_INCLUDE_DIR="${EPREFIX}/usr/include/trilinos"
 		-DTrilinos_INSTALL_LIB_DIR="${EPREFIX}/usr/$(get_libdir)/trilinos"
+		-DTrilinos_INSTALL_CONFIG_DIR="${EPREFIX}/usr/$(get_libdir)/cmake"
 		-DTPL_ENABLE_BinUtils=ON
 		-DTPL_ENABLE_MPI=ON
 		-DTPL_ENABLE_BLAS=ON


### PR DESCRIPTION
This commit fixes the installation path for the Trilinos project
configuration so that it now resides under $(get_libdir)/cmake instead of
$(get_libdir)/trilinos/cmake.

Furthermore, a version bump to 11.4.2
