### PR TITLE
=sci-mathematics/acl2-6.3 : Fix license, set USE="books" as default

### DIFF
--- a/sci-mathematics/acl2/acl2-6.3.ebuild
+++ b/sci-mathematics/acl2/acl2-6.3.ebuild
@@ -14,9 +14,9 @@ SRC_URI="
 	workshops? ( http://acl2-books.googlecode.com/files/workshops-${PV}.tar.gz ) )"
 
 SLOT="0"
-LICENSE="GPL-2"
+LICENSE="BSD"
 KEYWORDS="~amd64 ~x86"
-IUSE="books workshops html"
+IUSE="+books workshops html"
 
 REQUIRED_USE="workshops? ( books )"
 


### PR DESCRIPTION
A couple of changes. First, ACL2 has been licensed under the BSD 3-clause license for a few versions now. Second, I made the `books` use flag default to on, because it's basically a standard library for ACL2 and most programming language implementations on Gentoo tend to ship with their standard library. 
