### PR TITLE
sci-libs/cblas-reference: removed extra character that breaks make

### DIFF
--- a/sci-libs/cblas-reference/cblas-reference-20110218.ebuild
+++ b/sci-libs/cblas-reference/cblas-reference-20110218.ebuild
@@ -61,7 +61,7 @@ src_prepare() {
 		LOADER=\$(FC)
 		ARCH=$(tc-getAR)
 		ARCHFLAGS=cr
-	d	RANLIB=$(tc-getRANLIB)
+		RANLIB=$(tc-getRANLIB)
 	EOF
 }
 


### PR DESCRIPTION
typo? see bug https://bugs.gentoo.org/show_bug.cgi?id=495202
