### PR TITLE
Fixed ebuild fits-1.11.0 (Issue #167)

### DIFF
--- a/dev-java/fits/ChangeLog
+++ b/dev-java/fits/ChangeLog
@@ -2,6 +2,12 @@
 # Copyright 1999-2013 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+*fits-1.11.0-r1 (27 Dec 2013)
+
+  27 Dec 2013; Johann Schmitz <ercpe@gentoo.org> +fits-1.11.0-r1.ebuild,
+  -fits-1.11.0.ebuild:
+  Fixed ebuild fits-1.11.0
+
 *fits-1.11.0 (25 Jun 2013)
 
   25 Jun 2013; Sébastien Fabbro <bicatali@gentoo.org> +fits-1.11.0.ebuild,

--- a/dev-java/fits/fits-1.11.0-r1.ebuild
+++ b/dev-java/fits/fits-1.11.0-r1.ebuild
@@ -3,8 +3,10 @@
 # $Header: $
 
 EAPI=5
+
 JAVA_PKG_IUSE="doc source test"
-inherit eutils java-pkg-2 java-ant-2
+
+inherit java-pkg-2 java-ant-2
 
 DESCRIPTION="Java library for FITS input/output"
 HOMEPAGE="http://fits.gsfc.nasa.gov/fits_libraries.html#java_tam"
@@ -20,14 +22,13 @@ RDEPEND=">=virtual/jre-1.5
 	${CDEPEND}"
 DEPEND=">=virtual/jdk-1.5
 	test? (
-		dev-java/ant-junit4
-		dev-java/hamcrest-core
+		dev-java/ant-junit4:0
 	)
 	${CDEPEND}"
 
-EANT_EXTRA_ARGS="-Dpacakge.version=${PV}"
-EANT_GENTOO_CLASSPATH="junit-4"
+EANT_EXTRA_ARGS="-Dpackage.version=${PV}"
 JAVA_ANT_REWRITE_CLASSPATH="true"
+EANT_GENTOO_CLASSPATH="junit-4"
 
 src_unpack() {
 	mkdir -p ${P}/src && cd ${P}/src
@@ -40,15 +41,31 @@ java_prepare() {
 	epatch \
 		"${FILESDIR}"/01-Use-getResource-to-access-CompressTest-data-for-unit.patch \
 		"${FILESDIR}"/02-Update-ArrayFuncsTest.java-to-JUnit-4.patch
+
+	if ! use test; then
+		find "${S}" -name "*Test.java" -o -name "*Tester.java" | xargs rm || die
+	fi
+
+	# from http://heasarc.gsfc.nasa.gov/docs/heasarc/fits/java/v1.0/NOTE.v111.0:
+	# The source code JAR (fits_src.jar) includes a number of new classes for
+	# which the corresponding class files are not included in fits.jar.  These
+	# classes are pre-alpha versions of support for tile compressed data that 
+	# is being developed.  Interested Users may take a look at these, but they
+	# definitely are not expected to work today.
+	rm 	src/nom/tam/image/comp/Quantizer.java \
+		src/nom/tam/image/comp/RealStats.java \
+		src/nom/tam/image/comp/TiledImageHDU.java \
+		src/nom/tam/image/QuantizeRandoms.java \
+		src/nom/tam/image/TileDescriptor.java \
+		src/nom/tam/image/TileLooper.java || die
 }
 
 src_test() {
-	ANT_TASKS="ant-junit4" eant test
+	ANT_TASKS="ant-junit4" java-pkg-2_src_test
 }
 
 src_install() {
-	java-pkg_newjar build/${PN}.jar ${PN}.jar
+	java-pkg_dojar build/${PN}.jar
 	use doc && java-pkg_dojavadoc doc/api
 	use source && java-pkg_dosrc src/*
-	#use examples && java-pkg_doexamples src/java/examples
 }


### PR DESCRIPTION
I've dropped the .java file because it isn't in the binary jar file.
From http://heasarc.gsfc.nasa.gov/docs/heasarc/fits/java/v1.0/NOTE.v111.0:

The source code JAR (fits_src.jar) includes a number of new classes for
which the corresponding class files are not included in fits.jar.  These
classes are pre-alpha versions of support for tile compressed data that 
is being developed.  Interested Users may take a look at these, but they
definitely are not expected to work today.

The test cases are still broken.
