### PR TITLE
Make header installation work again

### DIFF
--- a/sci-physics/geant-vmc/ChangeLog
+++ b/sci-physics/geant-vmc/ChangeLog
@@ -2,6 +2,11 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  02 Feb 2014; <o.freyermuth@googlemail.com> geant-vmc-4.2.14b.ebuild,
+  geant-vmc-4.2.15.ebuild:
+  Make header installation work again, include/ contains folders only so
+  doheader must recurse
+
   06 Jan 2014; Justin Lecher <jlec@gentoo.org> geant-vmc-4.2.14b.ebuild,
   geant-vmc-4.2.15.ebuild, metadata.xml:
   Add missing die

--- a/sci-physics/geant-vmc/geant-vmc-4.2.14b.ebuild
+++ b/sci-physics/geant-vmc/geant-vmc-4.2.14b.ebuild
@@ -51,7 +51,7 @@ src_test() {
 
 src_install() {
 	dolib.so lib/tgt_*/{libg4root,libgeant4vmc}.so
-	doheader include/*
+	doheader -r include/*
 	dodoc README history version_number
 	use doc && dohtml -r Geant4VMC.html doc/*
 	if use examples; then

--- a/sci-physics/geant-vmc/geant-vmc-4.2.15.ebuild
+++ b/sci-physics/geant-vmc/geant-vmc-4.2.15.ebuild
@@ -50,7 +50,7 @@ src_test() {
 
 src_install() {
 	dolib.so lib/tgt_*/{libg4root,libgeant4vmc}.so
-	doheader include/*
+	doheader -r include/*
 	dodoc README history version_number
 	use doc && dohtml -r Geant4VMC.html doc/*
 	if use examples; then


### PR DESCRIPTION
include/ contains folders only so doheader must recurse (got broken in 4965054a93b9dd9f630a31b290e20c799dc1cf94 ), caused die in doins 
