### PR TITLE
[dev-lang/julia] PREFIX is now prefix

### DIFF
--- a/dev-lang/julia/ChangeLog
+++ b/dev-lang/julia/ChangeLog
@@ -2,6 +2,9 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  08 Feb 2014;  <xhochy@gentoo.org> julia-9999.ebuild:
+  PREFIX is now prefix
+
   26 Jan 2014;  <xhochy@gentoo.org> julia-9999.ebuild:
   Add missing dependency for utf8proc
 

--- a/dev-lang/julia/julia-9999.ebuild
+++ b/dev-lang/julia/julia-9999.ebuild
@@ -94,7 +94,7 @@ src_test() {
 }
 
 src_install() {
-	emake install PREFIX="${D}/usr"
+	emake install prefix="${D}/usr"
 	cat > 99julia <<-EOF
 		LDPATH=${EROOT%/}/usr/$(get_libdir)/julia
 	EOF


### PR DESCRIPTION
The variable prefix is now lowercase in the Makefile. Setting uppercase PREFIX will have no effect anymore.
