### PR TITLE
sci-libs/armadillo: Add patch with option to disable wrapper

### DIFF
--- a/sci-libs/armadillo/ChangeLog
+++ b/sci-libs/armadillo/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  14 Feb 2014; Reinis Danne <rei4dan@gmail.com> armadillo-4.000.3.ebuild,
+  +files/armadillo-opt_wrapper.patch:
+  Add patch to make the wrapper optional at consumer compile time.
+
   10 Feb 2014; Sébastien Fabbro <bicatali@gentoo.org> armadillo-4.000.3.ebuild:
   sci-libs/armadillo: removed int64 flag, it is only for revdep at compile time
 

--- a/sci-libs/armadillo/armadillo-4.000.3.ebuild
+++ b/sci-libs/armadillo/armadillo-4.000.3.ebuild
@@ -40,6 +40,7 @@ PDEPEND="${RDEPEND}
 src_prepare() {
 	epatch \
 		"${FILESDIR}"/${PN}-4.000.3-hdf5.patch \
+		"${FILESDIR}"/${PN}-opt_wrapper.patch \
 		"${FILESDIR}"/${PN}-3.820.1-example-makefile.patch
 	# avoid the automagic cmake macros
 	sed -i -e '/ARMA_Find/d' CMakeLists.txt || die

--- a/sci-libs/armadillo/files/armadillo-opt_wrapper.patch
+++ b/sci-libs/armadillo/files/armadillo-opt_wrapper.patch
@@ -1,0 +1,15 @@
+--- include/armadillo_bits/config.hpp.cmake	2014-02-14 02:22:31.792051878 +0200
++++ include/armadillo_bits/config.hpp.cmake	2014-02-14 02:24:56.423587416 +0200
+@@ -29,10 +29,12 @@
+ //// ARPACK is required for eigendecompositions of sparse matrices, eg. eigs_sym() 
+ #endif
+ 
++#if !defined(ARMA_NO_WRAPPER)
+ #cmakedefine ARMA_USE_WRAPPER
+ //// Comment out the above line if you're getting linking errors when compiling your programs,
+ //// or if you prefer to directly link with LAPACK, BLAS or ARPACK.
+ //// You will then need to link your programs directly with -llapack -lblas instead of -larmadillo
++#endif
+ 
+ // #define ARMA_BLAS_CAPITALS
+ //// Uncomment the above line if your BLAS and LAPACK libraries have capitalised function names (eg. ACML on 64-bit Windows)


### PR DESCRIPTION
With this programs can be built only against armadillo headers and
linked directly to math libraries by using -DARMA_NO_WRAPPER at compile
time.
