### PR TITLE
sci-visualization/visit: remove redundant dependency

### DIFF
--- a/sci-visualization/visit/visit-2.7.1.ebuild
+++ b/sci-visualization/visit/visit-2.7.1.ebuild
@@ -19,7 +19,6 @@ REQUIRED_USE="${PYTHON_REQUIRED_USE}"
 
 RDEPEND="
 	${PYTHON_DEPS}
-	sci-libs/silo
 	hdf5? ( sci-libs/hdf5 )
 	tcmalloc? ( dev-util/google-perftools )
 	cgns? ( sci-libs/cgnslib )


### PR DESCRIPTION
There is  `silo? ( sci-libs/silo )` under.
