### PR TITLE
Fix syntax bug in dependency atom (sci-physics/geant-vmc-3.1.15a)

### DIFF
--- a/sci-physics/geant-vmc/ChangeLog
+++ b/sci-physics/geant-vmc/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  31 Mar 2014; Oliver Freyermuth <o.freyermuth@googlemail.com>
+  geant-vmc-3.1.15a.ebuild:
+  Fix syntax bug in dependency atom
+
 *geant-vmc-4.2.15a (31 Mar 2014)
 
   31 Mar 2014; Oliver Freyermuth <o.freyermuth@googlemail.com>

--- a/sci-physics/geant-vmc/geant-vmc-3.1.15a.ebuild
+++ b/sci-physics/geant-vmc/geant-vmc-3.1.15a.ebuild
@@ -19,7 +19,7 @@ KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
 IUSE="examples"
 
 RDEPEND="
-	sci-physics/root[pythia6]:=
+	sci-physics/root:=[pythia6]
 	!sci-physics/geant:3"
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
Introduced by myself when adding subslot-dependency. 
I humbly bow in front of repoman full and promise to ask him before each commit. 
I shall not invoke echangelog manually, but call repoman commit instead. 
