### PR TITLE
app-editors/neovim: Added luajit dependency.

### DIFF
--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -26,4 +26,5 @@ IUSE=""
 RDEPEND="app-admin/eselect-vi
 	sys-libs/ncurses"
 DEPEND="${RDEPEND}
+	dev-lang/luajit
 	>=dev-libs/libuv-0.11.19"


### PR DESCRIPTION
If luajit is not installed then merge will fail with following output:

```
>>> Working in BUILD_DIR: "/var/tmp/portage/app-editors/neovim-9999/work/neovim-9999_build"                                                           [691/809]cmake --no-warn-unused-cli -C /var/tmp/portage/app-editors/neovim-9999/work/neovim-9999_build/gentoo_common_config.cmake -G Unix Makefiles -DCMAKE_INSTALL_PREF
IX=/usr -DCMAKE_BUILD_TYPE=Gentoo -DCMAKE_INSTALL_DO_STRIP=OFF -DCMAKE_USER_MAKE_RULES_OVERRIDE=/var/tmp/portage/app-editors/neovim-9999/work/neovim-9999_build
/gentoo_rules.cmake  /var/tmp/portage/app-editors/neovim-9999/work/neovim-9999
Not searching for unused variables given on the command line.
loading initial cache file /var/tmp/portage/app-editors/neovim-9999/work/neovim-9999_build/gentoo_common_config.cmake
-- The C compiler identification is GNU 4.7.3
-- The CXX compiler identification is GNU 4.7.3
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc
-- Check for working C compiler: /usr/bin/x86_64-pc-linux-gnu-gcc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++
-- Check for working CXX compiler: /usr/bin/x86_64-pc-linux-gnu-g++ -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Found PkgConfig: /usr/bin/x86_64-pc-linux-gnu-pkg-config (found version "0.28") 
-- Looking for dlopen in dl
-- Looking for dlopen in dl - found
-- Looking for kstat_lookup in kstat
-- Looking for kstat_lookup in kstat - not found
-- Looking for kvm_open in kvm
-- Looking for kvm_open in kvm - not found
-- Looking for gethostbyname in nsl
-- Looking for gethostbyname in nsl - found
-- Looking for perfstat_cpu in perfstat
-- Looking for perfstat_cpu in perfstat - not found
-- Looking for clock_gettime in rt
-- Looking for clock_gettime in rt - found
-- Looking for sendfile in sendfile
-- Looking for sendfile in sendfile - not found
-- Found LibUV: /usr/lib64/libuv.so  
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:108 (message):
  Could NOT find LuaJit (missing: LUAJIT_LIBRARY LUAJIT_INCLUDE_DIR)
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:315 (_FPHSA_FAILURE_MESSAGE)
  cmake/FindLuaJit.cmake:46 (find_package_handle_standard_args)
  CMakeLists.txt:49 (find_package)
```
