### PR TITLE
Use CFLAGS needed to get a working executable for neovim

### DIFF
--- a/app-editors/neovim/ChangeLog
+++ b/app-editors/neovim/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+  14 Jun 2014; Jelte Fennema (JelteF) <github-tech@jeltef.nl>
+  neovim-9999.ebuild:
+  Use CFLAGS needed to get a working executable
+
   10 May 2014; Jelte Fennema <github@jeltef.nl> neovim-9999.ebuild:
   Add new cmsgpack and lpeg dependencies to neovim.
 

--- a/app-editors/neovim/neovim-9999.ebuild
+++ b/app-editors/neovim/neovim-9999.ebuild
@@ -4,7 +4,7 @@
 
 EAPI=5
 
-inherit cmake-utils
+inherit cmake-utils flag-o-matic
 
 if [ "${PV}" = "9999" ]; then
 	EGIT_REPO_URI="git://github.com/neovim/neovim.git"
@@ -22,6 +22,11 @@ LICENSE="vim"
 SLOT="0"
 KEYWORDS=""
 IUSE=""
+
+src_configure()  {
+	append-flags "-DNDEBUG -Wno-error -D_FORTIFY_SOURCE=1"
+	cmake-utils_src_configure
+}
 
 RDEPEND="app-admin/eselect-vi
 	sys-libs/ncurses"


### PR DESCRIPTION
Neovim is now built using the CFLAGS needed for an actual working release version. The flags used come from this comment https://github.com/neovim/neovim/pull/715#issuecomment-44793621
