### PR TITLE
dev-util/nvidia-cuda-toolkit: Add profiler specific paths only with USE=profiler, #512160

### DIFF
--- a/dev-util/nvidia-cuda-toolkit/ChangeLog
+++ b/dev-util/nvidia-cuda-toolkit/ChangeLog
@@ -2,6 +2,13 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: $
 
+*nvidia-cuda-toolkit-6.5.11-r1 (14 Jul 2014)
+
+  14 Jul 2014; Marius Brehler <marbre@linux.sungazer.de>
+  +nvidia-cuda-toolkit-6.5.11-r1.ebuild, -nvidia-cuda-toolkit-6.5.11.ebuild:
+  dev-util/nvidia-cuda-toolkit: Add profiler specific paths only with
+  USE=profiler, #512160
+
 *nvidia-cuda-toolkit-6.5.11 (10 Jul 2014)
 
   10 Jul 2014; Marius Brehler <marbre@linux.sungazer.de> +files/cuda-config.in,

--- a/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.11-r1.ebuild
+++ b/dev-util/nvidia-cuda-toolkit/nvidia-cuda-toolkit-6.5.11-r1.ebuild
@@ -115,13 +115,14 @@ src_install() {
 	mv * "${ED}"${cudadir}
 
 	cat > "${T}"/99cuda <<- EOF
-		PATH=${ecudadir}/bin:${ecudadir}/libnvvp
+		PATH=${ecudadir}/bin$(use profiler && echo ":${ecudadir}/libnvvp")
 		ROOTPATH=${ecudadir}/bin
 		LDPATH=${ecudadir}/lib$(use amd64 && echo "64:${ecudadir}/lib")
 	EOF
 	doenvd "${T}"/99cuda
 
-	make_wrapper nvprof "${EPREFIX}"${cudadir}/bin/nvprof "." ${ecudadir}/lib$(use amd64 && echo "64:${ecudadir}/lib")
+	use profiler && \
+		make_wrapper nvprof "${EPREFIX}"${cudadir}/bin/nvprof "." ${ecudadir}/lib$(use amd64 && echo "64:${ecudadir}/lib")
 
 	dobin "${T}"/cuda-config
 }


### PR DESCRIPTION
Adopted nvidia-cuda-toolkit-6.0.37-r4.ebuild changes.

Package-Manager: portage-2.2.8-r1
