### PR TITLE
dev-python/astropy: Update astropy live ebuild deps and python support

### DIFF
--- a/dev-python/astropy/ChangeLog
+++ b/dev-python/astropy/ChangeLog
@@ -3,6 +3,9 @@
 # $Header: $
 
   11 Aug 2014; Joseph Jon Booker <joe@neoturbine.net> astropy-9999.ebuild:
+  dev-python/astropy: Fix python deps
+
+  11 Aug 2014; Joseph Jon Booker <joe@neoturbine.net> astropy-9999.ebuild:
   dev-python/astropy: Update astropy live ebuild deps and python support
 
   06 Jan 2014; Justin Lecher <jlec@gentoo.org> astropy-9999.ebuild:

--- a/dev-python/astropy/astropy-9999.ebuild
+++ b/dev-python/astropy/astropy-9999.ebuild
@@ -31,8 +31,8 @@ DEPEND="${RDEPEND}
 	dev-python/setuptools[${PYTHON_USEDEP}]
 	virtual/pkgconfig
 	doc? (
-		dev-python/matplotlib
-		dev-python/sphinx
+		dev-python/matplotlib[${PYTHON_USEDEP}]
+		dev-python/sphinx[${PYTHON_USEDEP}]
 		media-gfx/graphviz
 	)
 	test? (


### PR DESCRIPTION
Mostly a copy of the in-tree ebuild. Adds support for Python3 versions too.
