### PR TITLE
Add src_unpack to ensure mercurial_src_unpack is called

### DIFF
--- a/dev-cpp/eigen/eigen-9999.ebuild
+++ b/dev-cpp/eigen/eigen-9999.ebuild
@@ -50,6 +50,11 @@ RDEPEND="
 	!dev-cpp/eigen:0
 	${CDEPEND}"
 
+src_unpack() {
+	mercurial_src_unpack
+	vcs-snapshot_src_unpack
+}
+
 src_prepare() {
 	sed -i \
 		-e "s:/usr:${EPREFIX}/usr:g" \


### PR DESCRIPTION
The inheritance mechanism of ebuilds is such that functions not
overridden are taken from the last package inherited. In this case,
that is vcs-snapshot, which provides a src_unpack that does not clone
the mercurial repository. By explicitly providing src_unpack, we
guarantee that mercurial_src_unpack is called prior to
vcs-snapshot_src_unpack.
