### PR TITLE
ncbi-tools++: fix prefix libdir, muparser/hdf5 use flags

### DIFF
--- a/sci-biology/ncbi-tools++/ncbi-tools++-12.0.0.ebuild
+++ b/sci-biology/ncbi-tools++/ncbi-tools++-12.0.0.ebuild
@@ -57,7 +57,7 @@ DEPEND="
 	xerces? ( dev-libs/xerces-c )
 	xalan? ( dev-libs/xalan-c )
 	muparser? ( dev-cpp/muParser )
-	hdf5? ( sci-libs/hdf5 )
+	hdf5? ( sci-libs/hdf5[cxx] )
 	gif? ( media-libs/giflib )
 	jpeg? ( virtual/jpeg )
 	png? ( media-libs/libpng )
@@ -212,7 +212,6 @@ src_configure() {
 #	--with-included-sss
 	--with-z="${EPREFIX}/usr"
 	--with-bz2="${EPREFIX}/usr"
-	--with-muparser="${EPREFIX}/usr"
 	--without-sybase
 	--with-autodep
 #	--with-3psw=std:netopt favor standard (system) builds of the above pkgs
@@ -222,13 +221,14 @@ src_configure() {
 	$(use_with static-libs static)
 	$(use_with static static-exe)
 	$(use_with threads mt)
-	$(use_with prefix runpath "${EPREFIX}/usr/$(get_libdir)/ncbi_cxx")
+	$(use_with prefix runpath "${EPREFIX}/usr/$(get_libdir)/${PN}")
 	$(use_with test check)
 	$(use_with pch)
 	$(use_with lzo lzo "${EPREFIX}/usr")
 	$(use_with pcre pcre "${EPREFIX}/usr")
 	$(use_with gnutls gnutls "${EPREFIX}/usr")
 	$(use_with mysql mysql "${EPREFIX}/usr")
+	$(use_with muparser muparser "${EPREFIX}/usr")
 	$(usex fltk --with-fltk="${EPREFIX}/usr" "")
 	$(use_with opengl opengl "${EPREFIX}/usr")
 	$(use_with mesa mesa "${EPREFIX}/usr")


### PR DESCRIPTION
This patch fixes three things:
- prefix `--libdir`: libraries are installed in `${PN}`, but `runpath` is set to be `$(get_libdir)/ncbi_cxx`. This results in libraries not found when trying to run the built executables (as reported in #274)
- `USE=muparser`: `./configure` can fail because `--with-muparser=...` is given but no matter what the `USE` flag is set to, and `dev-cpp/muParser` is not necessarily installed
- `USE=hdf5`: `./configure` fails to find `libhdf5_cpp`, which is only built for `sci-libs/hdf5[cxx]`
