### PR TITLE
Drop prop-flags patch for root-9999

### DIFF
--- a/sci-physics/root/ChangeLog
+++ b/sci-physics/root/ChangeLog
@@ -2,6 +2,12 @@
 # Copyright 1999-2014 Gentoo Foundation; Distributed under the GPL v2
 # $Header: /var/cvsroot/gentoo-x86/sci-physics/root/ChangeLog,v 1.96 2012/03/29 18:21:49 bicatali Exp $
 
+  10 Nov 2014; Oliver Freyermuth <o.freyermuth@googlemail.com>
+  root-9999.ebuild:
+  Drop prop-flags patch for root-9999, patch fails starting from 5.34.23 and
+  ROOT 6 master. Upstream offers configure-flags to set proper flags starting
+  now. 
+
   25 Oct 2014; Matthias Maier <tamiko@gentoo.org> root-5.34.18-r2.ebuild,
   root-6.00.01-r1.ebuild, root-6.00.02.ebuild, root-9999.ebuild:
   sci-physics/root: Fix compilation with USE="mysql" wrt bug #523996; fix

--- a/sci-physics/root/root-9999.ebuild
+++ b/sci-physics/root/root-9999.ebuild
@@ -198,7 +198,6 @@ src_prepare() {
 		"${FILESDIR}"/${PN}-5.34.13-desktop.patch \
 		"${FILESDIR}"/${PN}-6.00.01-dotfont.patch \
 		"${FILESDIR}"/${PN}-6.00.01-nobyte-compile.patch \
-		"${FILESDIR}"/${PN}-6.00.01-prop-flags.patch \
 		"${FILESDIR}"/${PN}-6.00.01-llvm.patch \
 		"${FILESDIR}"/${PN}-6.00.01-geocad.patch
 
@@ -299,6 +298,8 @@ src_configure() {
 			--enable-soversion
 			--enable-table
 			--fail-on-missing
+			--cflags='${CFLAGS}'
+			--cxxflags='${CXXFLAGS}'
 			$(use_enable X x11)
 			$(use_enable X asimage)
 			$(use_enable X xft)


### PR DESCRIPTION
Patch fails starting from 5.34.23 and ROOT 6 master. Upstream offers configure-flags to set proper flags starting now => use these. See e.g. upstream's commit http://root.cern.ch/gitweb?p=root.git;a=commit;h=9963acbe3e425f23fb98447aa6db87e41a881751 and release-announcement for 5.34.23. 
