### PR TITLE
Enable testing for sci-visualization/mantid

### DIFF
--- a/sci-visualization/mantid/mantid-3.3.0.ebuild
+++ b/sci-visualization/mantid/mantid-3.3.0.ebuild
@@ -87,30 +87,30 @@ src_test() {
 	# Tests are not built by default
 	emake AllTests
 	# Run only the tests that work without data files or GUI access
-	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus'
-	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinitionParser'
-	ctest -R 'APITest_'		  --exclude-regex 'File|IO'
-	ctest -R 'PythonInterface_'	  --exclude-regex 'Load'
-	ctest -R 'PythonInterfaceCppTest_'
-	ctest -R 'PythonInterfaceKernel_' --exclude-regex 'PropertyHistory'
-	ctest -R 'PythonInterfaceGeometry_'
+	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus'	|| die
+	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinitionParser'	|| die
+	ctest -R 'APITest_'		  --exclude-regex 'File|IO'	|| die
+	ctest -R 'PythonInterface_'	  --exclude-regex 'Load'	|| die
+	ctest -R 'PythonInterfaceCppTest_'	|| die
+	ctest -R 'PythonInterfaceKernel_' --exclude-regex 'PropertyHistory'	|| die
+	ctest -R 'PythonInterfaceGeometry_'	|| die
 	# Too many failing tests for 'PythonAlgorithms_'
-	ctest -R 'PythonFunctions_'
-	ctest -R 'DataObjectsTest_'
-	ctest -R 'DataHandlingTest_'	  --exclude-regex 'Append|Chunk|File|Group|Load|Log|Save|PSD|Workspace|XML'
+	ctest -R 'PythonFunctions_'	|| die
+	ctest -R 'DataObjectsTest_'	|| die
+	ctest -R 'DataHandlingTest_'	  --exclude-regex 'Append|Chunk|File|Group|Load|Log|Save|PSD|Workspace|XML'	|| die
 	# Too many failing tests for 'AlgorithmTest_'
-	ctest -R 'CurveFittingTest_'	  --exclude-regex 'AugmentedLagrangian|FitPowderDiffPeaks|TabulatedFunction'
+	ctest -R 'CurveFittingTest_'	  --exclude-regex 'AugmentedLagrangian|FitPowderDiffPeaks|TabulatedFunction'	|| die
 	# Too many failing tests for 'CrystalTest_'
-	ctest -R 'ICatTest_'
-	ctest -R 'LiveDataTest_'	  --exclude-regex 'File'
-	ctest -R 'PSISINQTest_'		  --exclude-regex 'LoadFlexiNexus'
-	ctest -R 'MDAlgorithmsTest_'	  --exclude-regex 'LoadSQW'
-	ctest -R 'MDEventsTest_'	  --exclude-regex 'OneStepMDEW'
-	ctest -R 'ScriptRepositoryTest_'
-	ctest -R 'MantidQtAPITest_'
-	ctest -R 'MantidWidgetsTest_'
-	ctest -R 'CustomInterfacesTest_'  --exclude-regex 'IO|Load'
-	ctest -R 'SliceViewerMantidPlotTest_'
-	ctest -R 'SliceViewerTest_'
+	ctest -R 'ICatTest_'	|| die
+	ctest -R 'LiveDataTest_'	  --exclude-regex 'File'	|| die
+	ctest -R 'PSISINQTest_'		  --exclude-regex 'LoadFlexiNexus'	|| die
+	ctest -R 'MDAlgorithmsTest_'	  --exclude-regex 'LoadSQW'	|| die
+	ctest -R 'MDEventsTest_'	  --exclude-regex 'OneStepMDEW'	|| die
+	ctest -R 'ScriptRepositoryTest_'	|| die
+	ctest -R 'MantidQtAPITest_'	|| die
+	ctest -R 'MantidWidgetsTest_'	|| die
+	ctest -R 'CustomInterfacesTest_'  --exclude-regex 'IO|Load'	|| die
+	ctest -R 'SliceViewerMantidPlotTest_'	|| die
+	ctest -R 'SliceViewerTest_'	|| die
 	# All the MantidPlot* tests use the GUI
 }

--- a/sci-visualization/mantid/mantid-3.3.0.ebuild
+++ b/sci-visualization/mantid/mantid-3.3.0.ebuild
@@ -86,7 +86,15 @@ src_configure() {
 src_test() {
 	# Tests are not built by default
 	emake AllTests
-	# Run only the tests that work without data files or GUI access
+
+	# Many of the tests require data files not included in the source tarball.
+	# There are pull requests on Github to deal with this, so hopefully it
+	# will be fixed by the next release. See:
+	# https://github.com/mantidproject/mantid/pull/150
+	# http://trac.mantidproject.org/mantid/ticket/10869
+	# http://trac.mantidproject.org/mantid/ticket/10871
+
+	# For now we use a subset of tests that work without data files or GUI access
 	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus'	|| die
 	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinitionParser'	|| die
 	ctest -R 'APITest_'		  --exclude-regex 'File|IO'	|| die

--- a/sci-visualization/mantid/mantid-3.3.0.ebuild
+++ b/sci-visualization/mantid/mantid-3.3.0.ebuild
@@ -18,7 +18,6 @@ LICENSE="GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64"
 IUSE="doc +opencascade opencl paraview pch tcmalloc test"
-RESTRICT="test" # Testing requires sample data and X11 access
 
 # There is a list of dependencies on the Mantid website at:
 # http://www.mantidproject.org/Mantid_Prerequisites
@@ -87,5 +86,31 @@ src_configure() {
 src_test() {
 	# Tests are not built by default
 	emake AllTests
-	cmake-utils_src_test
+	# Run only the tests that work without data files or GUI access
+	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus'
+	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinitionParser'
+	ctest -R 'APITest_'		  --exclude-regex 'File|IO'
+	ctest -R 'PythonInterface_'	  --exclude-regex 'Load'
+	ctest -R 'PythonInterfaceCppTest_'
+	ctest -R 'PythonInterfaceKernel_' --exclude-regex 'PropertyHistory'
+	ctest -R 'PythonInterfaceGeometry_'
+	# Too many failing tests for 'PythonAlgorithms_'
+	ctest -R 'PythonFunctions_'
+	ctest -R 'DataObjectsTest_'
+	ctest -R 'DataHandlingTest_'	  --exclude-regex 'Append|Chunk|File|Group|Load|Log|Save|PSD|Workspace|XML'
+	# Too many failing tests for 'AlgorithmTest_'
+	ctest -R 'CurveFittingTest_'	  --exclude-regex 'AugmentedLagrangian|FitPowderDiffPeaks|TabulatedFunction'
+	# Too many failing tests for 'CrystalTest_'
+	ctest -R 'ICatTest_'
+	ctest -R 'LiveDataTest_'	  --exclude-regex 'File'
+	ctest -R 'PSISINQTest_'		  --exclude-regex 'LoadFlexiNexus'
+	ctest -R 'MDAlgorithmsTest_'	  --exclude-regex 'LoadSQW'
+	ctest -R 'MDEventsTest_'	  --exclude-regex 'OneStepMDEW'
+	ctest -R 'ScriptRepositoryTest_'
+	ctest -R 'MantidQtAPITest_'
+	ctest -R 'MantidWidgetsTest_'
+	ctest -R 'CustomInterfacesTest_'  --exclude-regex 'IO|Load'
+	ctest -R 'SliceViewerMantidPlotTest_'
+	ctest -R 'SliceViewerTest_'
+	# All the MantidPlot* tests use the GUI
 }

--- a/sci-visualization/mantid/mantid-3.3.0.ebuild
+++ b/sci-visualization/mantid/mantid-3.3.0.ebuild
@@ -84,6 +84,8 @@ src_configure() {
 }
 
 src_test() {
+	cd "${BUILD_DIR}" # For some reason this is not done automatically...
+
 	# Tests are not built by default
 	emake AllTests
 

--- a/sci-visualization/mantid/mantid-3.3.0.ebuild
+++ b/sci-visualization/mantid/mantid-3.3.0.ebuild
@@ -84,7 +84,7 @@ src_configure() {
 }
 
 src_test() {
-	cd "${BUILD_DIR}" # For some reason this is not done automatically...
+	pushd "${BUILD_DIR}" # For some reason this is not done automatically...
 
 	# Tests are not built by default
 	emake AllTests
@@ -97,8 +97,8 @@ src_test() {
 	# http://trac.mantidproject.org/mantid/ticket/10871
 
 	# For now we use a subset of tests that work without data files or GUI access
-	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus'	|| die
-	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinitionParser'	|| die
+	ctest -R 'KernelTest_'		  --exclude-regex 'Config|File|Glob|Nexus|V3D'	|| die
+	ctest -R 'GeometryTest_'	  --exclude-regex 'InstrumentDefinition|CompAssembly|DetectorGroup|PolygonEdge|Rectangular'	|| die
 	ctest -R 'APITest_'		  --exclude-regex 'File|IO'	|| die
 	ctest -R 'PythonInterface_'	  --exclude-regex 'Load'	|| die
 	ctest -R 'PythonInterfaceCppTest_'	|| die
@@ -107,20 +107,22 @@ src_test() {
 	# Too many failing tests for 'PythonAlgorithms_'
 	ctest -R 'PythonFunctions_'	|| die
 	ctest -R 'DataObjectsTest_'	|| die
-	ctest -R 'DataHandlingTest_'	  --exclude-regex 'Append|Chunk|File|Group|Load|Log|Save|PSD|Workspace|XML'	|| die
+	ctest -R 'DataHandlingTest_'	  --exclude-regex 'Append|Chunk|File|FindDetectorsPar|Group|Load|Log|Save|PSD|Workspace|XML'	|| die
 	# Too many failing tests for 'AlgorithmTest_'
-	ctest -R 'CurveFittingTest_'	  --exclude-regex 'AugmentedLagrangian|FitPowderDiffPeaks|TabulatedFunction'	|| die
+	# Too many failing tests for 'CurveFittingTest_'
 	# Too many failing tests for 'CrystalTest_'
 	ctest -R 'ICatTest_'	|| die
 	ctest -R 'LiveDataTest_'	  --exclude-regex 'File'	|| die
 	ctest -R 'PSISINQTest_'		  --exclude-regex 'LoadFlexiNexus'	|| die
-	ctest -R 'MDAlgorithmsTest_'	  --exclude-regex 'LoadSQW'	|| die
+	ctest -R 'MDAlgorithmsTest_'	  --exclude-regex 'LoadSQW|EvaluateMDFunction'	|| die
 	ctest -R 'MDEventsTest_'	  --exclude-regex 'OneStepMDEW'	|| die
 	ctest -R 'ScriptRepositoryTest_'	|| die
 	ctest -R 'MantidQtAPITest_'	|| die
-	ctest -R 'MantidWidgetsTest_'	|| die
+	ctest -R 'MantidWidgetsTest_'	  --exclude-regex 'MWRunFiles'	|| die
 	ctest -R 'CustomInterfacesTest_'  --exclude-regex 'IO|Load'	|| die
-	ctest -R 'SliceViewerMantidPlotTest_'	|| die
+	ctest -R 'SliceViewerMantidPlotTest_'	--exclude-regex 'SliceViewerPythonInterface'	|| die
 	ctest -R 'SliceViewerTest_'	|| die
 	# All the MantidPlot* tests use the GUI
+
+	popd
 }


### PR DESCRIPTION
The ebuild I recently submitted had `RESTRICT=test` -- this PR enables running the tests that aren't broken.
