### PR TITLE
sci-biology/ensembl{,-*}: add ebuilds

### DIFF
--- a/sci-biology/ensembl-compara/ensembl-compara-9999.ebuild
+++ b/sci-biology/ensembl-compara/ensembl-compara-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit git-r3 perl-functions
+
+DESCRIPTION="The Ensembl Compara Perl API and SQL schema"
+HOMEPAGE="http://www.ensembl.org/info/docs/api/"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/Ensembl/${PN}.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+DEPEND="sci-biology/bioperl"
+RDEPEND="${DEPEND}
+	sci-biology/ensembl"
+
+src_install() {
+	perl_set_version
+	insinto /usr/lib/perl5/${PERL_VERSION}
+	doins -r modules/*
+	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
+
+	insinto /usr/share/${PN}
+	doins -r scripts sql
+
+	dodoc README.md
+}

--- a/sci-biology/ensembl-compara/ensembl-compara-9999.ebuild
+++ b/sci-biology/ensembl-compara/ensembl-compara-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit git-r3 perl-functions
 

--- a/sci-biology/ensembl-compara/metadata.xml
+++ b/sci-biology/ensembl-compara/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-biology</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">Ensembl/ensembl-compara</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sci-biology/ensembl-compara/metadata.xml
+++ b/sci-biology/ensembl-compara/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <herd>sci-biology</herd>
-  <maintainer>
+  <maintainer type="project">
+    <email>sci-biology@gentoo.org</email>
+    <name>Gentoo Biology Project</name>
+  </maintainer>
+  <maintainer type="person">
     <email>mschu.dev@gmail.com</email>
     <name>Michael Schubert</name>
   </maintainer>

--- a/sci-biology/ensembl-funcgen/ensembl-funcgen-9999.ebuild
+++ b/sci-biology/ensembl-funcgen/ensembl-funcgen-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit git-r3 perl-functions
 

--- a/sci-biology/ensembl-funcgen/ensembl-funcgen-9999.ebuild
+++ b/sci-biology/ensembl-funcgen/ensembl-funcgen-9999.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit git-r3 perl-functions
+
+DESCRIPTION="The Ensembl Functional Genomics Perl API and SQL schema"
+HOMEPAGE="http://www.ensembl.org/info/docs/api/"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/Ensembl/${PN}.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+DEPEND="sci-biology/bioperl"
+RDEPEND="${DEPEND}
+	sci-biology/ensembl"
+
+src_install() {
+	perl_set_version
+	insinto /usr/lib/perl5/${PERL_VERSION}
+	doins -r modules/*
+	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
+
+	insinto /usr/share/${PN}
+	doins -r scripts sql
+
+	dodoc docs/*
+}

--- a/sci-biology/ensembl-funcgen/metadata.xml
+++ b/sci-biology/ensembl-funcgen/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-biology</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">Ensembl/ensembl-funcgen</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sci-biology/ensembl-funcgen/metadata.xml
+++ b/sci-biology/ensembl-funcgen/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <herd>sci-biology</herd>
-  <maintainer>
+  <maintainer type="project">
+    <email>sci-biology@gentoo.org</email>
+    <name>Gentoo Biology Project</name>
+  </maintainer>
+  <maintainer type="person">
     <email>mschu.dev@gmail.com</email>
     <name>Michael Schubert</name>
   </maintainer>

--- a/sci-biology/ensembl-io/ensembl-io-9999.ebuild
+++ b/sci-biology/ensembl-io/ensembl-io-9999.ebuild
@@ -1,0 +1,29 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit git-r3 perl-functions
+
+DESCRIPTION="The Ensembl IO Perl API and SQL schema"
+HOMEPAGE="http://www.ensembl.org/info/docs/api/"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/Ensembl/${PN}.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+DEPEND="sci-biology/bioperl"
+RDEPEND="${DEPEND}
+	sci-biology/ensembl"
+
+src_install() {
+	perl_set_version
+	insinto /usr/lib/perl5/${PERL_VERSION}
+	doins -r modules/*
+	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
+
+	dodoc doc/*.txt
+}

--- a/sci-biology/ensembl-io/ensembl-io-9999.ebuild
+++ b/sci-biology/ensembl-io/ensembl-io-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit git-r3 perl-functions
 

--- a/sci-biology/ensembl-io/metadata.xml
+++ b/sci-biology/ensembl-io/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-biology</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">Ensembl/ensembl-io</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sci-biology/ensembl-io/metadata.xml
+++ b/sci-biology/ensembl-io/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <herd>sci-biology</herd>
-  <maintainer>
+  <maintainer type="project">
+    <email>sci-biology@gentoo.org</email>
+    <name>Gentoo Biology Project</name>
+  </maintainer>
+  <maintainer type="person">
     <email>mschu.dev@gmail.com</email>
     <name>Michael Schubert</name>
   </maintainer>

--- a/sci-biology/ensembl-variation/ensembl-variation-9999.ebuild
+++ b/sci-biology/ensembl-variation/ensembl-variation-9999.ebuild
@@ -1,0 +1,40 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit git-r3 perl-functions
+
+DESCRIPTION="The Ensembl Variation Perl API and SQL schema"
+HOMEPAGE="http://www.ensembl.org/info/docs/api/"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/Ensembl/${PN}.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE=""
+
+DEPEND="sci-biology/bioperl"
+RDEPEND="${DEPEND}
+	sci-biology/ensembl"
+
+src_compile() {
+	cd C_code
+	emake
+}
+
+src_install() {
+	perl_set_version
+	insinto /usr/lib/perl5/${PERL_VERSION}
+	doins -r modules/*
+	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
+
+	insinto /usr/share/${PN}
+	doins -r schema scripts sql
+
+	insinto /usr/bin
+	doins C_code/calc_genotypes
+
+	dodoc README.md documentation/*
+}

--- a/sci-biology/ensembl-variation/ensembl-variation-9999.ebuild
+++ b/sci-biology/ensembl-variation/ensembl-variation-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit git-r3 perl-functions
 
@@ -20,7 +20,7 @@ RDEPEND="${DEPEND}
 	sci-biology/ensembl"
 
 src_compile() {
-	cd C_code
+	cd C_code || die
 	emake
 }
 

--- a/sci-biology/ensembl-variation/metadata.xml
+++ b/sci-biology/ensembl-variation/metadata.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-biology</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <upstream>
+    <remote-id type="github">Ensembl/ensembl-variation</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sci-biology/ensembl-variation/metadata.xml
+++ b/sci-biology/ensembl-variation/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <herd>sci-biology</herd>
-  <maintainer>
+  <maintainer type="project">
+    <email>sci-biology@gentoo.org</email>
+    <name>Gentoo Biology Project</name>
+  </maintainer>
+  <maintainer type="person">
     <email>mschu.dev@gmail.com</email>
     <name>Michael Schubert</name>
   </maintainer>

--- a/sci-biology/ensembl/ensembl-9999.ebuild
+++ b/sci-biology/ensembl/ensembl-9999.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=5
+
+inherit git-r3 perl-functions
+
+DESCRIPTION="The Ensembl Perl API and SQL schema"
+HOMEPAGE="http://www.ensembl.org/info/docs/api/"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/Ensembl/${PN}.git"
+
+LICENSE="Apache-2.0"
+SLOT="0"
+IUSE="+variation +funcgen +compara +io"
+
+DEPEND="sci-biology/bioperl"
+RDEPEND="${DEPEND}
+	variation? ( sci-biology/ensembl-variation )
+	funcgen? ( sci-biology/ensembl-funcgen )
+	compara? ( sci-biology/ensembl-compara )
+	io? ( sci-biology/ensembl-io )"
+
+src_install() {
+	perl_set_version
+# the line below should work but doesn't (double prefix)
+#	insinto "${VENDOR_LIB}/EnsEMBL"
+	insinto /usr/lib/perl5/${PERL_VERSION}
+	doins -r modules/*
+	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
+
+	insinto /usr/share/${PN}
+	doins -r misc-scripts
+	doins -r sql
+
+	dodoc README.md
+}

--- a/sci-biology/ensembl/ensembl-9999.ebuild
+++ b/sci-biology/ensembl/ensembl-9999.ebuild
@@ -2,7 +2,7 @@
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
-EAPI=5
+EAPI=6
 
 inherit git-r3 perl-functions
 
@@ -24,15 +24,12 @@ RDEPEND="${DEPEND}
 
 src_install() {
 	perl_set_version
-# the line below should work but doesn't (double prefix)
-#	insinto "${VENDOR_LIB}/EnsEMBL"
 	insinto /usr/lib/perl5/${PERL_VERSION}
 	doins -r modules/*
 	rm -r "${ED}"/usr/lib/perl5/${PERL_VERSION}/t || die
 
 	insinto /usr/share/${PN}
-	doins -r misc-scripts
-	doins -r sql
+	doins -r misc-scripts sql
 
 	dodoc README.md
 }

--- a/sci-biology/ensembl/metadata.xml
+++ b/sci-biology/ensembl/metadata.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <herd>sci-biology</herd>
+  <maintainer>
+    <email>mschu.dev@gmail.com</email>
+    <name>Michael Schubert</name>
+  </maintainer>
+  <use>
+    <flag name="variation">Install variation module</flag>
+    <flag name="funcgen">Install functional genomics module</flag>
+    <flag name="compara">Install compara module</flag>
+    <flag name="io">Install io module</flag>
+  </use>
+  <upstream>
+    <remote-id type="github">Ensembl/ensembl</remote-id>
+  </upstream>
+</pkgmetadata>

--- a/sci-biology/ensembl/metadata.xml
+++ b/sci-biology/ensembl/metadata.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <herd>sci-biology</herd>
-  <maintainer>
+  <maintainer type="project">
+    <email>sci-biology@gentoo.org</email>
+    <name>Gentoo Biology Project</name>
+  </maintainer>
+  <maintainer type="person">
     <email>mschu.dev@gmail.com</email>
     <name>Michael Schubert</name>
   </maintainer>


### PR DESCRIPTION
EnsEMBL Perl API with the 4 additional default modules:
- io
- compara
- variation
- funcgen

I'm not entirely sure if I handle the depends - the way I organized it is to have the core with optional use flags, which are run deps only.

I also don't usually use Perl, so please tell me if I overlooked something obvious.
