### PR TITLE
dev-vcs/datalad: new ebuild

### DIFF
--- a/dev-vcs/datalad/datalad-9999.ebuild
+++ b/dev-vcs/datalad/datalad-9999.ebuild
@@ -37,6 +37,10 @@ RDEPEND="
 	dev-python/msgpack[${PYTHON_USEDEP}]
 	dev-vcs/git-annex"
 
-src_test() {
-	emake test-code
+python_test() {
+	git config --global user.name "TESTING"; \
+        git config --global user.email "TESTING@example.com"
+	distutils_install_for_testing
+	#cd "${TEST_DIR}"/lib || die
+	nosetests || die
 }

--- a/dev-vcs/datalad/datalad-9999.ebuild
+++ b/dev-vcs/datalad/datalad-9999.ebuild
@@ -1,0 +1,42 @@
+# Copyright 1999-2016 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+# $Id$
+
+EAPI=6
+
+PYTHON_COMPAT=( python2_7 python3_4 )
+
+inherit distutils-r1 git-r3
+
+DESCRIPTION="Data distribution system"
+HOMEPAGE="http://datalad.org"
+SRC_URI=""
+EGIT_REPO_URI="git://github.com/datalad/datalad"
+
+LICENSE="MIT"
+SLOT="0"
+KEYWORDS=""
+IUSE="test"
+
+DEPEND="
+	test? ( dev-python/nose[${PYTHON_USEDEP}] )
+	dev-python/setuptools[${PYTHON_USEDEP}]
+	"
+RDEPEND="
+	app-arch/patool[${PYTHON_USEDEP}]
+	dev-python/appdirs[${PYTHON_USEDEP}]
+	>=dev-python/git-python-2[${PYTHON_USEDEP}]
+	dev-python/humanize[${PYTHON_USEDEP}]
+	dev-python/mock[${PYTHON_USEDEP}]
+	dev-python/six[${PYTHON_USEDEP}]
+	>=dev-python/keyring-8[${PYTHON_USEDEP}]
+	dev-python/keyrings_alt[${PYTHON_USEDEP}]
+	dev-python/progressbar[${PYTHON_USEDEP}]
+	dev-python/requests[${PYTHON_USEDEP}]
+	dev-python/boto[${PYTHON_USEDEP}]
+	dev-python/msgpack[${PYTHON_USEDEP}]
+	dev-vcs/git-annex"
+
+src_test() {
+	emake test-code
+}

--- a/dev-vcs/datalad/datalad-9999.ebuild
+++ b/dev-vcs/datalad/datalad-9999.ebuild
@@ -38,8 +38,8 @@ RDEPEND="
 	dev-vcs/git-annex"
 
 python_test() {
-	git config --global user.name "TESTING"; \
-        git config --global user.email "TESTING@example.com"
+	git config user.name "TESTING"
+	git config user.email "TESTING@example.com"
 	distutils_install_for_testing
 	#cd "${TEST_DIR}"/lib || die
 	nosetests || die

--- a/dev-vcs/datalad/datalad-9999.ebuild
+++ b/dev-vcs/datalad/datalad-9999.ebuild
@@ -38,8 +38,8 @@ RDEPEND="
 	dev-vcs/git-annex"
 
 python_test() {
-	git config user.name "TESTING"
-	git config user.email "TESTING@example.com"
+	git config --global user.name "TESTING"
+	git config --global user.email "TESTING@example.com"
 	distutils_install_for_testing
 	#cd "${TEST_DIR}"/lib || die
 	nosetests || die

--- a/dev-vcs/datalad/metadata.xml
+++ b/dev-vcs/datalad/metadata.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+  <maintainer type="person">
+    <email>horea.christ@gmail.com</email>
+    <name>Horea Christian</name>
+  </maintainer>
+  <maintainer type="project">
+    <email>sci@gentoo.org</email>
+    <name>Gentoo Science Project</name>
+  </maintainer>
+  <longdescription lang="en">
+    DataLad aims to provide access to scientific data available from various
+    sources through a single convenient interface and integrated with your
+    software package managers.
+  </longdescription>
+  <upstream>
+    <remote-id type="github">datalad/datalad</remote-id>
+  </upstream>
+</pkgmetadata>


### PR DESCRIPTION
Builds nicely, and the tests pass if I run `nosetests datalad` a my user after install (except for two, but that's an upstream issue). However, if I run the tests via portage [all are either skipped, or give me errors, or fail](https://bpaste.net/show/67e83f91c78b).

It seems this is at last in part because the tests expect git to be configured (which is teh case for my normal user - but not for the portage user, obviously). @jlec @yarikoptic - how could I make more of these tests work?
