### PR TITLE
sci-mathematics/scilab: Require xml-commons-external-1.3, and unmask.

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -34,7 +34,6 @@
 # rev dep absent
 sci-biology/genseed
 sci-biology/tgicl
-sci-mathematics/scilab
 
 # Justin Lecher <jlec@gentoo.org> (24 April 2016)
 # rev dep missing keywords

--- a/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
+++ b/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
@@ -80,7 +80,7 @@ DEPEND="${CDEPEND}
 	gui? (
 		>=virtual/jdk-1.6
 		doc? ( app-text/docbook-xsl-stylesheets
-			   dev-java/xml-commons-external:1.4
+			   dev-java/xml-commons-external:1.3
 			   dev-java/saxon:9 )
 		xcos? ( dev-lang/ocaml )
 		)
@@ -177,7 +177,7 @@ src_prepare() {
 		if use doc; then
 			java-pkg_jar-from --build-only batik-1.8 batik-all.jar
 			java-pkg_jar-from --build-only saxon-9 saxon.jar saxon9he.jar
-			java-pkg_jar-from --build-only xml-commons-external-1.4 xml-apis-ext.jar
+			java-pkg_jar-from --build-only xml-commons-external-1.3 xml-apis-ext.jar
 		fi
 	fi
 	if use emf; then


### PR DESCRIPTION
Scilab requires xml-commons-external's xml-apis-ext.jar.  xml-commons-external-1.3 provides this but 1.4 has a different JAR name, and Scilab's configure phase breaks as a result (even with both 1.3 and 1.4 installed).  This makes it build again by downgrading the dep to 1.3.

Package-Manager: portage-2.3.0