### PR TITLE
eclass/intel-sdp-r1: fix for the MPI wrapper scripts

### DIFF
--- a/eclass/intel-sdp-r1.eclass
+++ b/eclass/intel-sdp-r1.eclass
@@ -537,6 +537,15 @@ intel-sdp-r1_src_install() {
 		eend
 	fi
 
+	if use mpi; then
+		ebegin "Setting MPI root path"
+		_escaped_root=$(echo $(isdp_get-sdp-edir) | sed 's_/_\\/_g')
+		for i in $(find "$(isdp_get-sdp-dir)/linux/mpi/" -type f -name "mpi*"); do
+    			sed -i "s/I_MPI_SUBSTITUTE_INSTALLDIR/"${_escaped_root}"\/linux\/mpi/g" "$i"
+  		done
+		eend
+	fi
+
 	# MPI man pages
 	if path_exists "$(isdp_get-sdp-dir)/linux/mpi/man/man3"; then
 		doman "$(isdp_get-sdp-dir)"/linux/mpi/man/man3/*

--- a/eclass/intel-sdp-r1.eclass
+++ b/eclass/intel-sdp-r1.eclass
@@ -537,14 +537,12 @@ intel-sdp-r1_src_install() {
 		eend
 	fi
 
-	if use mpi; then
-		ebegin "Setting MPI root path"
-		_escaped_root=$(echo $(isdp_get-sdp-edir) | sed 's_/_\\/_g')
-		for i in $(find "$(isdp_get-sdp-dir)/linux/mpi/" -type f -name "mpi*"); do
-    			sed -i "s/I_MPI_SUBSTITUTE_INSTALLDIR/"${_escaped_root}"\/linux\/mpi/g" "$i"
-  		done
-		eend
-	fi
+	ebegin "Setting MPI root path"
+	_escaped_root=$(echo $(isdp_get-sdp-edir) | sed 's_/_\\/_g')
+	for i in $(find "$(isdp_get-sdp-dir)/linux/mpi/" -type f -name "mpi*"); do
+    		sed -i "s/I_MPI_SUBSTITUTE_INSTALLDIR/"${_escaped_root}"\/linux\/mpi/g" "$i"
+  	done
+	eend
 
 	# MPI man pages
 	if path_exists "$(isdp_get-sdp-dir)/linux/mpi/man/man3"; then


### PR DESCRIPTION
All MPI wrapper scripts were not working as the I_MPI_SUBSTITUTE_INSTALLDIR string was not replaced by the actual root dir. This commits adds a substitution for I_MPI_SUBSTITUTE_INSTALLDIR trough sed.