### PR TITLE
sci-libs/labbookdb: new ebuild

### DIFF
--- a/sci-libs/labbookdb/labbookdb-9999.ebuild
+++ b/sci-libs/labbookdb/labbookdb-9999.ebuild
@@ -1,0 +1,27 @@
+# Copyright 1999-2017 Gentoo Foundation
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=6
+
+PYTHON_COMPAT=( python{2_7,3_4,3_5} )
+
+inherit distutils-r1 git-r3
+
+DESCRIPTION="Organize and rename large numbers of files"
+HOMEPAGE="https://github.com/TheChymera/LabbookDB"
+SRC_URI=""
+EGIT_REPO_URI="https://github.com/TheChymera/LabbookDB"
+
+LICENSE="GPL-3"
+SLOT="0"
+IUSE=""
+KEYWORDS=""
+
+DEPEND=""
+RDEPEND="
+	dev-python/argh[${PYTHON_USEDEP}]
+	dev-python/numpy[${PYTHON_USEDEP}]
+	<=dev-python/pandas-0.20.3[${PYTHON_USEDEP}]
+	dev-python/simplejson[${PYTHON_USEDEP}]
+	dev-python/sqlalchemy[${PYTHON_USEDEP}]
+	"

--- a/sci-libs/labbookdb/metadata.xml
+++ b/sci-libs/labbookdb/metadata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
+<pkgmetadata>
+	<maintainer type="person">
+		<email>horea.christ@yandex.com</email>
+		<name>Horea Christian</name>
+	</maintainer>
+	<longdescription lang="en">
+		A relational database standard for life science research, including a 
+		number of functions to conveniently add and retrieve information - and
+		generate summaries.
+	</longdescription>
+	<upstream>
+		<remote-id type="github">TheChymera/LabbookDB</remote-id>
+	</upstream>
+</pkgmetadata>


### PR DESCRIPTION
New ebuild to manage lab metadata and notes. Upstream is me:

* [On GitHub](https://github.com/TheChymera/LabbookDB).
* [Peer reviewed](http://conference.scipy.org/proceedings/scipy2017/horea-ioan_ioanas.html).

Package-Manager: Portage-2.3.13, Repoman-2.3.4