### PR TITLE
sci-biology/fastqc does not install the package's java code

### DIFF
--- a/sci-biology/fastqc/fastqc-0.11.3.ebuild
+++ b/sci-biology/fastqc/fastqc-0.11.3.ebuild
@@ -1,31 +1,27 @@
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2020 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit java-pkg-2 eutils java-ant-2
+inherit java-pkg-2 eutils java-ant-2 prefix
 
 DESCRIPTION="Quality control FASTA/FASTQ sequence files"
-HOMEPAGE="http://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
-SRC_URI="http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v"${PV}"_source.zip"
+HOMEPAGE="https://www.bioinformatics.babraham.ac.uk/projects/fastqc/"
+SRC_URI="https://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v"${PV}"_source.zip"
 
 LICENSE="GPL-3+"
 SLOT="0"
-KEYWORDS=""
-IUSE=""
+KEYWORDS="~amd64"
 
-DEPEND="sci-biology/picard
-	sci-libs/jhdf5
-	>=virtual/jre-1.5:*"
-RDEPEND="${DEPEND}
-	dev-lang/perl
-	>=virtual/jdk-1.5:*
-	dev-java/ant-core"
+RDEPEND="dev-lang/perl"
+DEPEND="${RDEPEND} >=virtual/jdk-1.5:*"
+BDEPEND="app-arch/unzip"
 
 S="${WORKDIR}"/FastQC
 
 src_prepare(){
 	cp "${FILESDIR}"/build.xml . || die
+	default
 }
 
 src_compile(){
@@ -33,22 +29,20 @@ src_compile(){
 }
 
 src_install(){
-	dobin fastqc run_fastqc.bat
-	dodoc README.txt RELEASE_NOTES.txt
+	insinto "opt/${PN}"
+	doins -r bin
+	chmod a+x "${ED}/opt/${PN}/bin/fastqc"
+	# Add the package's bin directory to the PATH.
+	doenvd "${FILESDIR}/00fastqc"
+	if use prefix ; then
+		hprefixify "${ED}/etc/env.d/00fastqc"
+	fi
 
-	# There is no fastqc.jar.  The output from the compilation is the set of
-	# .class files (a jar file is just a zip file full of .class files).  All
-	# you need to copy out is the contents of the bin subdirectory, the rest of
-	# the download you can discard.
-	#
-	# jbzip2-0.9.jar comes from https://code.google.com/p/jbzip2
-	#
-	# ignore the sam-1.103.jar and rely on /usr/share/picard/lib/sam.jar from sci-biology/picard
-	# The sam-1.103.jar library comes from
-	# http://sourceforge.net/projects/picard/files/sam-jdk/.  Note that there is
-	# a newer version of this codebase at https://github.com/samtools/htsjdk but
-	# that FastQC is NOT yet compatible with the updated API (this will probably
-	# happen in a future release).  This library is needed to read SAM/BAM
-	# format files.
-	# cisd-jhdf5.jar should be provided by sci-libs/jhdf5
+	dodoc README.txt RELEASE_NOTES.txt
+}
+
+pkg_postinst() {
+	ewarn "Remember to run: env-update && source \"${EPREFIX}/etc/profile\" if you plan"
+	ewarn "to use this tool in a shell before logging out (or restarting"
+	ewarn "your login manager)"
 }

--- a/sci-biology/fastqc/files/00fastqc
+++ b/sci-biology/fastqc/files/00fastqc
@@ -1,0 +1,1 @@
+PATH="/opt/fastqc/bin"

--- a/sci-biology/fastqc/metadata.xml
+++ b/sci-biology/fastqc/metadata.xml
@@ -5,6 +5,10 @@
 		<email>mmokrejs@fold.natur.cuni.cz</email>
 		<name>Martin Mokrejs</name>
 	</maintainer>
+	<maintainer type="person">
+		<email>anton.stay.connected@gmail.com</email>
+		<name>Anton Molyboha</name>
+	</maintainer>
 	<maintainer type="project">
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>


### PR DESCRIPTION
It looks like sci-biology/fastqc-0.11.3 is supposed to install some java *.class files but fails to do so.

'emerge sci-biology/fastqc' completes without an error, but when I try running fastqc with any meaningful options, I am getting:
  Error: Could not find or load main class uk.ac.babraham.FastQC.FastQCApplication

The ebuild's src_install() only installs the wrapper scripts and docs, and has a comment:

    dobin fastqc run_fastqc.bat
    dodoc README.txt RELEASE_NOTES.txt
    
    # There is no fastqc.jar.  The output from the compilation is the set of
    # .class files (a jar file is just a zip file full of .class files).  All
    # you need to copy out is the contents of the bin subdirectory, the rest of
    # the download you can discard.
    [... snip the discussion of where to get dependencies]

I am guessing that the .class files mentioned in the comment should also be installed somewhere (not really sure where, though) If my guess is true, I will come up with a work-around and will post it here.