### PR TITLE
Fix dolfin lib dir for multilib-strict.

### DIFF
--- a/sci-mathematics/dolfin/dolfin-2017.1.0.ebuild
+++ b/sci-mathematics/dolfin/dolfin-2017.1.0.ebuild
@@ -52,6 +52,7 @@ RDEPEND="${DEPEND}"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-2016.2.0-trilinos-superlu.patch
+	"${FILESDIR}"/${PN}-2017.1.1-cmake-libdir.patch
 )
 
 pkg_setup() {

--- a/sci-mathematics/dolfin/files/dolfin-2017.1.0-cmake-libdir.patch
+++ b/sci-mathematics/dolfin/files/dolfin-2017.1.0-cmake-libdir.patch
@@ -1,0 +1,21 @@
+diff -Naur dolfin-2017.1.0/CMakeLists.txt dolfin-2017.1.0-patched/CMakeLists.txt
+--- dolfin-2017.1.0/CMakeLists.txt	2017-05-09 10:01:18.000000000 -0500
++++ dolfin-2017.1.0-patched/CMakeLists.txt	2017-12-01 16:00:05.815502160 -0600
+@@ -73,6 +73,8 @@
+ # Make sure CMake uses the correct DOLFINConfig.cmake for tests and demos
+ set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} ${CMAKE_CURRENT_BINARY_DIR}/dolfin)
+ 
++INCLUDE(GNUInstallDirs)
++
+ #------------------------------------------------------------------------------
+ # Configurable options for how we want to build
+ 
+@@ -797,7 +799,7 @@
+ 
+ # Set DOLFIN install sub-directories
+ set(DOLFIN_BIN_DIR "bin" CACHE PATH "Binary installation directory.")
+-set(DOLFIN_LIB_DIR "lib" CACHE PATH "Library installation directory.")
++set(DOLFIN_LIB_DIR ${CMAKE_INSTALL_FULL_LIBDIR} CACHE PATH "Library installation directory.")
+ set(DOLFIN_INCLUDE_DIR "include" CACHE PATH "C/C++ header installation directory.")
+ set(DOLFIN_PKGCONFIG_DIR "lib/pkgconfig" CACHE PATH "pkg-config file installation directory.")
+ set(DOLFIN_SHARE_DIR "share/dolfin" CACHE PATH "Shared data installation directory.")


### PR DESCRIPTION
This package also came up while discussing multilib-strict issues for libmed.

The issue is largely the same with this package. Library defaulting to install in /usr/lib. The solution is only slightly different because upstream sets a variable to "lib" and the "install(TARGET" function calls that variable. So I chose to leave the "instalI(TARGET" call alone, and set the variable it uses to ${CMAKE_INSTALL_FULL_LIBDIR}.

Again I added an include statement to CMakeLists.txt for GNUInstallDirs to gain access to the ${CMAKE_INSTALL_FULL_LIBDIR} macro.