### PR TITLE
sci-mathematics/scilab: Fix compilation w/ gcc-8

### DIFF
--- a/sci-mathematics/scilab/files/scilab-5.5.2-fix-argsize.patch
+++ b/sci-mathematics/scilab/files/scilab-5.5.2-fix-argsize.patch
@@ -1,0 +1,14 @@
+Martin V\"ath <martin at mvath.de>
+The argument arrays in subroutine tridv were larger than needed and larger
+than passed when called. This leads to errors on compilers like gcc-8
+--- a/modules/differential_equations/src/fortran/twodq.f
++++ a/modules/differential_equations/src/fortran/twodq.f
+@@ -900,7 +900,7 @@
+       END
+ 
+       subroutine tridv(node,node1,node2,coef,rank)
+-      double precision node(10),node1(10),node2(10),coef
++      double precision node(9),node1(9),node2(9),coef
+       integer rank
+       double precision s(3),coef1,temp
+       integer t(3)

--- a/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
+++ b/sci-mathematics/scilab/scilab-5.5.2-r1.ebuild
@@ -114,6 +114,7 @@ PATCHES=(
 	"${FILESDIR}/${P}-fop-2.0.patch"
 	"${FILESDIR}/${P}-xmlgraphics-common-2.0.patch"
 	"${FILESDIR}/${P}-freehep.patch"
+	"${FILESDIR}/${P}-fix-argsize.patch"
 )
 
 pkg_pretend() {


### PR DESCRIPTION
The argument arrays in subroutine tridv were larger than needed and larger
than passed when called.