### PR TITLE
sci-libs/atlas: fix CFLAGS comma interpretation

### DIFF
--- a/sci-libs/atlas/atlas-3.11.39-r1.ebuild
+++ b/sci-libs/atlas/atlas-3.11.39-r1.ebuild
@@ -1,4 +1,4 @@
-# Copyright 1999-2017 Gentoo Foundation
+# Copyright 1999-2018 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -27,6 +27,7 @@ S="${WORKDIR}/ATLAS"
 
 PATCHES=(
 	"${FILESDIR}"/${P}-dolastcomp.patch
+	"${FILESDIR}"/${P}-getdoublearr.patch
 )
 
 pkg_setup() {
@@ -112,7 +113,7 @@ src_configure() {
 		fi
 		# generic stuff found by make make xprint_enums in atlas build dir
 		# basically assuming sse2+sse1 and 2 threads max
-		use generic && use x86   && myconf+=( "-V 384 -A 13")
+		use generic && use x86	 && myconf+=( "-V 384 -A 13")
 		use generic && use amd64 && myconf+=( "-V 384 -A 24")
 
 		local confdir="${S}_${1}"; shift

--- a/sci-libs/atlas/files/atlas-3.11.39-getdoublearr.patch
+++ b/sci-libs/atlas/files/atlas-3.11.39-getdoublearr.patch
@@ -1,0 +1,28 @@
+Fix misparsing of double array in case CFLAGS contains commas
+
+--- ATLAS/include/atlas_genparse.h	2015-10-10 07:14:37.000000000 +0200
++++ ATLAS/include/atlas_genparse.h	2015-12-25 11:05:52.283348877 +0100
+@@ -224,21 +224,22 @@
+ /* procedure 11 */
+ static int GetDoubleArr(char *str, int N, double *d)
+ /*
+  * Reads in a list with form "%le,%le...,%le"; N-length d recieves doubles.
+  * RETURNS: the number of doubles found, or N, whichever is less
+  */
+ {
+    int i=1;
++   char *end = strstr(str, " ");  /* Stop parsing after a space */
+    assert(sscanf(str, "%le", d) == 1);
+    while (i < N)
+    {
+       str = strstr(str, ",");
+-      if (!str)
++      if (!str || (end && str >= end))
+          break;
+       str++;
+       assert(sscanf(str, "%le", d+i) == 1);
+       i++;
+    }
+    return(i);
+ }
+ 


### PR DESCRIPTION
Fixes ``GetDoubleArr: Assertion `sscanf(str, "%le", d+i) == 1' failed.``
See: https://sourceforge.net/p/math-atlas/support-requests/1014/

Package-Manager: Portage-2.3.43, Repoman-2.3.10