### PR TITLE
sci-astronomy/libthesky: Fix build failure with USE=static-libs.

### DIFF
--- a/sci-astronomy/libthesky/libthesky-0.4.1-r1.ebuild
+++ b/sci-astronomy/libthesky/libthesky-0.4.1-r1.ebuild
@@ -5,6 +5,7 @@ EAPI=7
 
 CMAKE_BUILD_TYPE=Release
 inherit cmake fortran-2
+CMAKE_MAKEFILE_GENERATOR="emake"
 
 DESCRIPTION="Fortran library to compute positions of celestial bodies"
 HOMEPAGE="http://libthesky.sourceforge.net/"

--- a/sci-astronomy/libthesky/metadata.xml
+++ b/sci-astronomy/libthesky/metadata.xml
@@ -2,8 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>AstroFloyd@gmail.com</email>
-		<name>AstroFloyd</name>
+		<email>git@vandersluys.nl</email>
+		<name>MarcvdSluys</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>sci-astronomy@gentoo.org</email>


### PR DESCRIPTION
sci-astronomy/libthesky-0.4.1 fails to build with USE=static-libs.  Using emake as the CMake Makefile
generator, instead of ninja, fixes this.

Package-Manager: Portage-3.0.4, Repoman-3.0.1