### PR TITLE
sci-libs/libsufr: Fix build failure with USE=static-libs.

### DIFF
--- a/sci-libs/libsufr/libsufr-0.7.5-r1.ebuild
+++ b/sci-libs/libsufr/libsufr-0.7.5-r1.ebuild
@@ -5,6 +5,7 @@ EAPI=7
 
 CMAKE_BUILD_TYPE=Release
 inherit cmake fortran-2
+CMAKE_MAKEFILE_GENERATOR="emake"
 
 DESCRIPTION="LIBrary of Some Useful Fortran Routines"
 HOMEPAGE="http://libsufr.sourceforge.net/"

--- a/sci-libs/libsufr/metadata.xml
+++ b/sci-libs/libsufr/metadata.xml
@@ -2,12 +2,8 @@
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
-		<email>AstroFloyd@gmail.com</email>
-		<name>AstroFloyd</name>
-	</maintainer>
-	<maintainer type="person">
-		<email>xarthisius@gentoo.org</email>
-		<name>Kacper Kowalik</name>
+		<email>git@vandersluys.nl</email>
+		<name>MarcvdSluys</name>
 	</maintainer>
 	<maintainer type="project">
 		<email>sci@gentoo.org</email>


### PR DESCRIPTION
sci-libs/libsufr-0.7.5 fails to build with USE=static-libs. Using emake as the CMake Makefile
generator, instead of ninja, fixes this.

Package-Manager: Portage-3.0.4, Repoman-3.0.1