### PR TITLE
sci-biology/gffutils: drop py3.6, drop old

### DIFF
--- a/sci-biology/gffutils/gffutils-0.10.1.ebuild
+++ b/sci-biology/gffutils/gffutils-0.10.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit distutils-r1
 
@@ -13,8 +13,7 @@ SRC_URI="https://github.com/daler/gffutils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	dev-python/simplejson[${PYTHON_USEDEP}]

--- a/sci-biology/gffutils/gffutils-0.8.7.1.ebuild
+++ b/sci-biology/gffutils/gffutils-0.8.7.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{6..9} )
+PYTHON_COMPAT=( python3_{7..9} )
 
 inherit distutils-r1
 
@@ -13,8 +13,7 @@ SRC_URI="https://github.com/daler/gffutils/archive/v${PV}.tar.gz -> ${P}.tar.gz"
 
 LICENSE="MIT"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
-IUSE=""
+KEYWORDS="~amd64 ~x86"
 
 RDEPEND="
 	sci-biology/pyfaidx[${PYTHON_USEDEP}]


### PR DESCRIPTION
py3.6 has been dropped from dep in ::gentoo
repoman is unhappy about it

Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>