### PR TITLE
sci-libs/itk: drop old python targets

### DIFF
--- a/sci-libs/itk/itk-5.0.1.ebuild
+++ b/sci-libs/itk/itk-5.0.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit toolchain-funcs cmake python-single-r1
 
@@ -25,7 +25,7 @@ SRC_URI="
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~x86"
 IUSE="debug doc examples fftw python review test vtkglue"
 RESTRICT="!test? ( test )"
 # python will not work, this is a know issue upstream:

--- a/sci-libs/itk/itk-5.1.0.ebuild
+++ b/sci-libs/itk/itk-5.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python2_7 python3_{6,7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9} )
 
 inherit toolchain-funcs cmake python-single-r1
 
@@ -35,7 +35,7 @@ SRC_URI="
 
 LICENSE="Apache-2.0"
 SLOT="0"
-KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux"
+KEYWORDS="~amd64 ~x86"
 IUSE="debug doc examples fftw python review test vtkglue"
 RESTRICT="!test? ( test )"
 # python will not work, this is a know issue upstream:


### PR DESCRIPTION
Package-Manager: Portage-3.0.12, Repoman-3.0.2
Signed-off-by: Andrew Ammerlaan <andrewammerlaan@riseup.net>