### PR TITLE
require 0 or oneof (cuda rocm)

### DIFF
--- a/sci-libs/pytorch/pytorch-1.7.1-r2.ebuild
+++ b/sci-libs/pytorch/pytorch-1.7.1-r2.ebuild
@@ -58,7 +58,7 @@ KEYWORDS="~amd64"
 IUSE="asan blas cuda +fbgemm ffmpeg gflags glog +gloo leveldb lmdb mkldnn mpi namedtensor +nnpack numa +observers opencl opencv +openmp +python +qnnpack redis rocm static test tools zeromq"
 RESTRICT="!test? ( test )"
 REQUIRED_USE="
-	^^ ( cuda rocm )
+	?? ( cuda rocm )
 "
 
 RDEPEND="


### PR DESCRIPTION
require 0 or oneof (cuda rocm), instead of exactely oneof (cuda rocm)
this should solve https://github.com/gentoo/sci/issues/1044