### PR TITLE
dev-perl/BTLib: add blocker

### DIFF
--- a/dev-perl/BTLib/BTLib-0.19.ebuild
+++ b/dev-perl/BTLib/BTLib-0.19.ebuild
@@ -13,4 +13,7 @@ LICENSE="|| ( Artistic GPL-1 GPL-2 GPL-3 )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
+RDEPEND="
+	!app-misc/sphinx"
+
 SRC_TEST="do"

--- a/dev-perl/BTLib/BTLib-0.20.ebuild
+++ b/dev-perl/BTLib/BTLib-0.20.ebuild
@@ -13,4 +13,7 @@ LICENSE="|| ( Artistic GPL-1 GPL-2 GPL-3 )"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
 
+RDEPEND="
+	!app-misc/sphinx"
+
 SRC_TEST="do"


### PR DESCRIPTION
* add blocker against app-misc/sphinx.
* added for both versions 0.19 and 0.20.

Currently, the package dev-perl/BTLib has file collisions with
app-misc/sphinx; therefore, they cannot be merged at on the same
system.
This commit adds blockers to all versions of dev-perl/BTLib
against app-misc/sphinx.
With this commit, they will not be able to be installed on the same
system, which solves the file collision problem.
Without this commit, a file collision detection will occur during
emerge.
This bug is similar to and was solved in the same method to
Bug: https://bugs.gentoo.org/756865.
This commit was tested locally within a docker w/ ebuildtester.
This commit was tested, written, and submitted by Lucas Mitrak.

Closes: https://bugs.gentoo.org/756796
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>