### PR TITLE
 sci-libs/fox: add inherit fortran-2

### DIFF
--- a/sci-libs/fox/fox-4.1.2-r2.ebuild
+++ b/sci-libs/fox/fox-4.1.2-r2.ebuild
@@ -28,6 +28,8 @@ S="${WORKDIR}/${MY_P}"
 
 FORTRAN_STANDARD=90
 
+DEPEND="sys-devel/gcc[fortran]"
+
 PATCHES=(
 	"${FILESDIR}"/4.1.2-r2-install-customizations.patch
 )

--- a/sci-libs/fox/fox-4.1.2-r2.ebuild
+++ b/sci-libs/fox/fox-4.1.2-r2.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit fortran-2
+
 MY_PN="FoX"
 MY_P="${MY_PN}-${PV}"
 
@@ -27,8 +29,6 @@ SRC_URI="
 S="${WORKDIR}/${MY_P}"
 
 FORTRAN_STANDARD=90
-
-DEPEND="sys-devel/gcc[fortran]"
 
 PATCHES=(
 	"${FILESDIR}"/4.1.2-r2-install-customizations.patch


### PR DESCRIPTION
* inherit fortran-2 to sci-libs/fox

Currently, sci-libs/fox does not require a fortran compiler
to be installed. If sci-libs/fox is emerged without the fortran
compiler, the configure phase will check for a fortran compiler, and the
configure phase will fail. For example, the hardened profile disables
the fortran USE flag in sys-devel/gcc, so sci-libs/fox will fail.
With this commit, sci-libs/fox will require a fortran compiler
to be installed.
Without this commit, sci-libs/fox will fail on any system which does
not have the fortran compiler, which by default is all hardened profiles.
This commit was tested in a docker image with dev-util/ebuildtester.
This commit was written, tested, and submitted by Lucas Mitrak.

Closes: https://bugs.gentoo.org/757771
Signed-off-by: Lucas Mitrak lucas@lucasmitrak.com