### PR TITLE
 sci-mathematics/gappa: Add multiprocessing.eclass for makeopts_jobs

### DIFF
--- a/sci-mathematics/gappa/gappa-1.3.5.ebuild
+++ b/sci-mathematics/gappa/gappa-1.3.5.ebuild
@@ -3,6 +3,8 @@
 
 EAPI=7
 
+inherit multiprocessing
+
 DESCRIPTION="Verifying and proving properties on floating-point or fixed-point arithmetic"
 HOMEPAGE="http://gappa.gforge.inria.fr/"
 SRC_URI="https://gforge.inria.fr/frs/download.php/file/38044/${P}.tar.gz"
@@ -28,12 +30,8 @@ src_prepare() {
 }
 
 src_compile() {
-	# Remove --load-average or -l because remake does not accept these
-	echo ${MAKEOPTS} | egrep -o '(\-l|\-\-load\-average)(=?|[[:space:]]*)[[:digit:]]+' > /dev/null
-	if [ $? -eq 0 ]; then
-		MAKEOPTS="${MAKEOPTS/$(echo ${MAKEOPTS} | egrep -o '(\-l|\-\-load\-average)(=?|[[:space:]]*)[[:digit:]]+')/}"
-	fi
-	./remake -d ${MAKEOPTS} || die "emake failed"
+	# Only accept number of parrellel jobs because remake does not understand --load-average
+	./remake -d -j$(makeopts_jobs) || die "emake failed"
 	if use doc; then
 		./remake doc/html/index.html
 	fi

--- a/sci-mathematics/gappa/gappa-1.3.5.ebuild
+++ b/sci-mathematics/gappa/gappa-1.3.5.ebuild
@@ -28,6 +28,11 @@ src_prepare() {
 }
 
 src_compile() {
+	# Remove --load-average or -l because remake does not accept these
+	echo ${MAKEOPTS} | egrep -o '(\-l|\-\-load\-average)(=?|[[:space:]]*)[[:digit:]]+' > /dev/null
+	if [ $? -eq 0 ]; then
+		MAKEOPTS="${MAKEOPTS/$(echo ${MAKEOPTS} | egrep -o '(\-l|\-\-load\-average)(=?|[[:space:]]*)[[:digit:]]+')/}"
+	fi
 	./remake -d ${MAKEOPTS} || die "emake failed"
 	if use doc; then
 		./remake doc/html/index.html


### PR DESCRIPTION
* Add inherit multiprocessing.eclass for makeopts_jobs

Currently, sci-mathematics/gappa will fail to compile if either -l or
--load-average is set in ${MAKEOPTS} because remake does not accept
them. This commit adds the implements the makeopts_jobs within the
multiprocessing eclass to ensure only --jobs are passed to remake.
This will allow the package to compile and install
correctly even with --load-average in MAKEOPTS.
This commit was tested in a docker image with dev-util/ebuildtester.
This commit was written, tested, and submitted by Lucas Mitrak.

Closes: https://bugs.gentoo.org/568368
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>