### PR TITLE
sci-biology/dcm2niix: add patch

### DIFF
--- a/sci-biology/dcm2niix/dcm2niix-1.0.20201102.ebuild
+++ b/sci-biology/dcm2niix/dcm2niix-1.0.20201102.ebuild
@@ -16,6 +16,10 @@ KEYWORDS="~amd64 ~x86"
 DEPEND=""
 RDEPEND=""
 
+PATCHES=(
+	"${FILESDIR}"/${PN}-disable_find_git.patch
+)
+
 pkg_postinst() {
 	optfeature "parallel gzip support" app-arch/pigz
 }

--- a/sci-biology/dcm2niix/files/dcm2niix-disable_find_git.patch
+++ b/sci-biology/dcm2niix/files/dcm2niix-disable_find_git.patch
@@ -1,0 +1,19 @@
+disable finding git because it should not be used nor needed
+Written and tested by Lucas Mitrak.
+https://bugs.gentoo.org/755746
+
+--- a/SuperBuild/SuperBuild.cmake
++++ b/SuperBuild/SuperBuild.cmake
+@@ -1,8 +1,8 @@
+ # Check if git exists
+-find_package(Git)
+-if(NOT GIT_FOUND)
+-    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
+-endif()
++#find_package(Git)
++#if(NOT GIT_FOUND)
++#    message(FATAL_ERROR "Cannot find Git. Git is required for Superbuild")
++#endif()
+ 
+ # Use git protocol or not
+ option(USE_GIT_PROTOCOL "If behind a firewall turn this off to use http instead." ON)


### PR DESCRIPTION
* Disable finding git in cmake
* Add patch to ebuild

Currently, sci-biology/dcm2niix will not compile if git is not found.
The patch dcm2niix-disable_find_git.patch comments out the lines which
attempt to find git and require it to be found. With this patch, the
package will compile correctly. Without this patch, cmake will throw
an error if git is not found.
This commit was tested in a docker image with dev-util/ebuildtester.
This commit was written, tested, and submitted by Lucas Mitrak.

Closes: https://bugs.gentoo.org/755746
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>