### PR TITLE
sci-biology/dcm2niix: add USE flags, dependencies, src_configure

### DIFF
--- a/sci-biology/dcm2niix/dcm2niix-1.0.20201102.ebuild
+++ b/sci-biology/dcm2niix/dcm2niix-1.0.20201102.ebuild
@@ -12,13 +12,29 @@ SRC_URI="https://github.com/rordenlab/dcm2niix/archive/v${PV}.tar.gz -> ${P}.tar
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86"
+IUSE="static system-jpeg +jpeg-ls jpeg2k"
 
-DEPEND=""
-RDEPEND=""
+DEPEND="
+	system-jpeg? ( media-libs/libjpeg-turbo )
+	jpeg2k? ( media-libs/openjpeg )
+"
+RDEPEND="${DEPEND}"
+BDEPEND="virtual/pkgconfig"
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-disable_find_git.patch
 )
+
+src_configure() {
+	local mycmakeargs=(
+		-DUSE_STATIC_RUNTIME=$(usex static)
+		-DUSE_TURBOJPEG=$(usex system-jpeg)
+		-DUSE_JPEGLS=$(usex jpeg-ls)
+		-DUSE_OPENJPEG=$(usex jpeg2k)
+	)
+
+	cmake_src_configure
+}
 
 pkg_postinst() {
 	optfeature "parallel gzip support" app-arch/pigz

--- a/sci-biology/dcm2niix/metadata.xml
+++ b/sci-biology/dcm2niix/metadata.xml
@@ -9,6 +9,11 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<use>
+	<flag name="system-jpeg">Use the system-wide <pkg>media-libs/libjpeg-turbo</pkg>
+		instead of bundled.</flag>
+	<flag name="jpeg-ls">Supprt for converting DICOM images compressed with the JPEG-LS transfer syntaxes using the bundled CharLS library</flag>
+	</use>
 	<longdescription>
 		dcm2niix is a designed to convert neuroimaging data from the DICOM
 		format to the NIfTI format. ICOM provides many ways to store/compress


### PR DESCRIPTION
* Add static system-jpeg +jpeg-ls jpeg2k use flags and implement them

Currently, sci-biology/dcm2niix does not take advantage of many
of the package's potential features. These potential features include
a static runtime, using the system-wide media-libs/libjpeg-turbo
instead of bundled compact NanoJPEG decoder, enabling JPEG-LS using
the bundled CharLS library, and enabling JPEG2000 support. These are
important, especially since the static runtime is enabled by default
and JPEG-LS can be enabled without any downside. This commit adds
these USE flags and their implementation in the dependencies and in
src_configure. The naming of the use flags follow the same naming
convention found elsewhere. For example, system-jpeg is the same
as thunderbird, firefox, and seamonkey. In addition, jpeg-ls is the
only possible name for the JPEG-LS transfer syntaxes. These two
package-specific USE flag names were added to metadata.xml.
With this commit, the use flags will be added to the package.
Without this commit, the package will not have these potential
features.
This commit was tested in a docker image with dev-util/ebuildtester.
This commit was written, tested, and submitted by Lucas Mitrak.
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>