### PR TITLE
scripts/setup-and-run-repoman.sh: use 'sort -V' to get latest tag

### DIFF
--- a/scripts/setup-and-run-repoman.sh
+++ b/scripts/setup-and-run-repoman.sh
@@ -16,7 +16,7 @@ git clone https://github.com/gentoo/portage.git
 cd portage
 
 # Get all versions, and read into array
-mapfile -t RM_VERSIONS < <( git tag | grep repoman | sort -u )
+mapfile -t RM_VERSIONS < <( git tag | grep repoman | sort -uV )
 
 # Select latests version (last element in array)
 RM_VERS="${RM_VERSIONS[-1]}"


### PR DESCRIPTION
The `scripts/setup-and-run-repoman.sh` script uses the `sort` program to get the latest repoman release from the Portage Git tree, but without the `-V` option, it can falsely identify versions like `2.3.9` to be newer than `2.3.10`:
```console
$ git tag | grep repoman | sort -u
repoman-2.3.0
repoman-2.3.1
repoman-2.3.10
repoman-2.3.11
repoman-2.3.12
repoman-2.3.13
repoman-2.3.14
repoman-2.3.15
repoman-2.3.16
repoman-2.3.17
repoman-2.3.18
repoman-2.3.19
repoman-2.3.2
repoman-2.3.20
repoman-2.3.21
repoman-2.3.22
repoman-2.3.23
repoman-2.3.3
repoman-2.3.5
repoman-2.3.6
repoman-2.3.7
repoman-2.3.8
repoman-2.3.9
repoman-3.0.0
repoman-3.0.1
repoman-3.0.2
repoman-3.0.3
```
The script should still work fine now because it might take a while for repoman to get to 3.0.10, but once that happens, it will become a minor issue.

Note that the copy of this script under [`gentoo/guru`](https://github.com/gentoo/guru/blob/master/scripts/setup-and-run-repoman.sh#L19) has this issue too.  If you would like me to submit another pull request for that one as well, please let me know!