### PR TITLE
sci-biology/SEECER: EAPI bump, patch, remove files, fix build system

### DIFF
--- a/sci-biology/SEECER/SEECER-0.1.3-r3.ebuild
+++ b/sci-biology/SEECER/SEECER-0.1.3-r3.ebuild
@@ -1,0 +1,66 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools toolchain-funcs
+
+DESCRIPTION="SEquence Error Corrector for RNA-Seq reads"
+HOMEPAGE="http://sb.cs.cmu.edu/seecer/"
+SRC_URI="
+	http://sb.cs.cmu.edu/seecer/downloads/"${P}".tar.gz
+	http://sb.cs.cmu.edu/seecer/downloads/manual.pdf -> "${PN}"-manual.pdf"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64"
+
+# although has bundled jellyfish-1.1.11 copy it just calls the executable during runtime
+# seems jellyfish-2 does not accept same commandline arguments
+DEPEND="
+	sci-libs/gsl:0=
+	sci-biology/seqan:0="
+RDEPEND="${DEPEND}
+	sci-biology/jellyfish:1"
+
+S="${WORKDIR}/${P}/SEECER"
+
+PATCHES=(
+	"${FILESDIR}"/remove-hardcoded-paths.patch
+	"${FILESDIR}"/run_seecer.sh.patch
+	"${FILESDIR}"/run_jellyfish.sh.patch
+	"${FILESDIR}"/${PN}-increase-max-sequence-length.patch
+	"${FILESDIR}"/${PN}-remove-flags.patch
+)
+
+pkg_pretend(){
+	# openmp is a hard requirement due to no gomp switch and source code assuming it is available
+	[[ ${MERGE_TYPE} != "binary" ]] && tc-check-openmp
+}
+
+pkg_setup(){
+	[[ ${MERGE_TYPE} != "binary" ]] && tc-check-openmp
+}
+
+src_prepare(){
+	rm -f bin/.run*.swp || die
+	rm -f src/*.o pipeline/*.o || die
+	rm -rf seqan-cxx || die
+	default
+	eautoreconf -i
+}
+
+src_configure(){
+	econf \
+		--with-seqan-include-path=/usr/include/seqan \
+		CXXFLAGS="${CXXFLAGS}"
+}
+
+src_install(){
+	dobin bin/seecer bin/random_sub_N bin/replace_ids bin/run_jellyfish.sh bin/run_seecer.sh
+	dodoc README "${DISTDIR}"/"${PN}"-manual.pdf
+}
+
+pkg_postinst(){
+	einfo "Note that the default kmer size 17 is terribly suboptimal, use k=31 instead"
+}

--- a/sci-biology/SEECER/files/SEECER-increase-max-sequence-length.patch
+++ b/sci-biology/SEECER/files/SEECER-increase-max-sequence-length.patch
@@ -1,0 +1,44 @@
+Increase the max sequence length from 256 to 10000
+Patch created from an updated replace_ids.cc downloaded from an archived upstream email list that is no longer online
+https://web.archive.org/web/20150911132231/http://seecer-rna-read-error-correction-mailing-list.21961.x6.nabble.com/Segmentation-fault-in-step-4-td41.html
+
+--- SEECER-0.1.3/pipeline/replace_ids.cc
++++ SEECER-0.1.3/pipeline/replace_ids.cc
+@@ -5,6 +5,7 @@
+ 
+ #include <vector>
+ using namespace std;
++#define MAXSEQLENGTH 10000  
+ 
+ char* getread(int& rid, char* annot, char* seq, FILE* f2, FILE* f3) {
+   char a;
+@@ -47,10 +48,10 @@ void closeFiles(vector<FILE*>& files) {
+ 
+ bool ReadNextLines(FILE* f, char* id, char* seq) {
+     assert(!feof(f));
+-    fgets(id, 256, f);
++    fgets(id, MAXSEQLENGTH, f);
+     if (id[0] == '+') {
+-	if (!fgets(id, 256, f)) return false;
+-	if (!fgets(id, 256, f)) return false;
++	if (!fgets(id, MAXSEQLENGTH, f)) return false;
++	if (!fgets(id, MAXSEQLENGTH, f)) return false;
+     }
+     int i = 0;
+     while (id[i+1] != '\0' && id[i+1] != '\n') {
+@@ -78,11 +79,10 @@ int main(int argc, char* argv[]) {
+       && origs.size() == output.size()) {
+ 
+     int n = origs.size();
+-  
+-    char id[256];
+-    char seq[256];
+-    char seqc[256];
+-    char annot[256];
++    char id[MAXSEQLENGTH];
++    char seq[MAXSEQLENGTH];
++    char seqc[MAXSEQLENGTH];
++    char annot[MAXSEQLENGTH];
+     int rid;
+     char a;
+ 

--- a/sci-biology/SEECER/files/SEECER-remove-flags.patch
+++ b/sci-biology/SEECER/files/SEECER-remove-flags.patch
@@ -1,0 +1,30 @@
+Remove CXXFLAGS, CFLAGS, LDCLAGS set in configure.ac and Makefile.am
+Written and tested by Lucas Mitrak
+
+--- SEECER-0.1.3/Makefile.am
++++ SEECER-0.1.3/Makefile.am
+@@ -1,6 +1,6 @@
+ AM_LDFLAGS = -lgomp
+ AM_CPPFLAGS = -Wno-deprecated -Wall $(SEQAN_CFLAGS) -fopenmp
+-AM_CXXFLAGS = -O3 -g
++AM_CXXFLAGS =
+ 
+ bin_PROGRAMS = bin/seecer \
+ 	bin/random_sub_N \
+--- SEECER-0.1.3/configure.ac
++++ SEECER-0.1.3/configure.ac
+@@ -2,10 +2,10 @@ AC_INIT([seecer], [1.0], [hple@cs.cmu.edu,maschulz@cs.cmu.edu])
+ AM_INIT_AUTOMAKE([-Wall subdir-objects  foreign])
+ AC_PREREQ(2.62)
+ 
+-: ${CXXFLAGS=""}
+-CFLAGS="$CFLAGS -I/opt/local/include"
+-CXXFLAGS="$CXXFLAGS -I/opt/local/include"
+-LDFLAGS="$LDFLAGS -L/opt/local/lib"
++#: ${CXXFLAGS=""}
++#CFLAGS="$CFLAGS -I/opt/local/include"
++#CXXFLAGS="$CXXFLAGS -I/opt/local/include"
++#LDFLAGS="$LDFLAGS -L/opt/local/lib"
+ AC_PROG_CXX
+ 
+ AC_CONFIG_HEADERS([config.h])


### PR DESCRIPTION
* EAPI bump
* Remove "rename_jellyfish_binary.patch" from ebuild which does nothing
* Add a patch that increases the max sequence length
* Add a patch that removes CXXFLAGS, CFLAGS, LDFLAGS
* Add tc-check-openmp so the ebuild fails without OpenMP support
* Remove copying a new replace_ids.cc file which is now a patch
* Delete all object files
* Delete packaged seqan
* Add eautoreconf to recreate the build system
* Add system seqan include path and CXXFLAGS to econf

Currently, sci-biology/SEECER will not compile due to object files
remaining in the package. This was fixed by deleting all object files
and so forcing them to be rebuilt. The packaged seqan was deleted as
well so the system's seqan is used. In order to achieve this, the
system's seqan include path was passed into econf as
"/usr/include/seqan". The user's CXXFLAGS were passed into econf also.
The patch SEECER-remove-flags.patch removes any other CXXFLAGS, CFLAGS,
and LDFLAGS present in configure.ac and Makefile.am.
Since configure.ac and Makefile.am were updated, the build system was
recreated using eautoreconf -i to account for this. The -i was needed
because the "compile" file is missing, so it had to be added. The patch
SEECER-increase-max-sequence-length.patch increases the max sequence
length from 256 to 10000. This patch was made from an updated
replace_ids.cc downloaded from an archived upstream mail list
that is no longer available online [1]. The previous revision ebuild
included this same replace_ids.cc file; however, despite it appearing
as a text file, it was actually a gzipped file with an incorrect
extension. In addition, this gzipped file was copied into the src/
directory when the replace_ids.cc file is in the pipeline/ directory.
The patch file "rename_jellyfish_binary.patch" also did nothing
but modify a comment so it was removed as well. In addition,
a tc-check-openmp was added so the ebuild fails without OpenMP support.
OpenMP cannot be added as a use flag or a configure enable flag because
gomp is always enabled and the source code assumes the system has OpenMP
installed. Finally, the EAPI was bumped.

[1] URL Split into three parts for the sake of the commit message:
https://web.archive.org/web/20150911132231/
http://seecer-rna-read-error-correction-mailing-list.21961.x6.nabble.com
/Segmentation-fault-in-step-4-td41.html

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>