### PR TITLE
sci-mathematics/flocq: EAPI bump, add multiprocessing to remake

### DIFF
--- a/sci-mathematics/flocq/flocq-3.4.0.ebuild
+++ b/sci-mathematics/flocq/flocq-3.4.0.ebuild
@@ -1,7 +1,9 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+inherit multiprocessing
 
 DESCRIPTION="A floating-point formalization for the Coq system"
 HOMEPAGE="http://flocq.gforge.inria.fr/"
@@ -26,7 +28,7 @@ src_configure() {
 }
 
 src_compile() {
-	./remake || die "emake failed"
+	./remake --jobs=$(makeopts_jobs) || die "emake failed"
 }
 
 src_install() {


### PR DESCRIPTION
* EAPI bump from 7 to 8
* Add multiprocessing to remake using the $(makeopts_jobs) variable

Currently, sci-mathematics/flocq does not have multiprocessing even
though the homepage [1] states this is available. This is done by
adding --jobs=$(makeopts_jobs) to remake. the makeopts_jobs
variable comes from the multiprocessing eclass.

[1] http://flocq.gforge.inria.fr/

Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>