### PR TITLE
sci-mathematics/acl2: fix TAGS install, add emacs/doc flags, etc

### DIFF
--- a/sci-mathematics/acl2/acl2-8.3-r1.ebuild
+++ b/sci-mathematics/acl2/acl2-8.3-r1.ebuild
@@ -1,0 +1,86 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit elisp-common
+
+DESCRIPTION="Industrial strength theorem prover"
+HOMEPAGE="https://www.cs.utexas.edu/users/moore/acl2/"
+SRC_URI="https://github.com/acl2/acl2/archive/${PV}/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64 ~x86"
+IUSE="books doc emacs"
+
+BDEPEND="
+	dev-lisp/sbcl
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+DEPEND="
+	dev-lisp/sbcl:=
+	books? ( dev-lang/perl )
+	doc? ( dev-lang/perl )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-use_make_variable.patch )
+
+src_prepare() {
+	find . -type f -name "*.bak" -delete
+	find . -type f -name "*.orig" -delete
+	# Remove sparc binary inadvertently included in upstream
+	rm books/workshops/2003/schmaltz-al-sammane-et-al/support/acl2link || die
+	default
+}
+
+src_compile() {
+	emake LISP="sbcl --noinform --noprint \
+		--no-sysinit --no-userinit --disable-debugger"
+
+	if use books; then
+		emake "ACL2=${S}/saved_acl2" basic
+	fi
+
+	if use doc; then
+		emake "ACL2=${S}/saved_acl2" DOC
+	fi
+
+	if use emacs; then
+		elisp-compile emacs/*.el
+	fi
+}
+
+src_install() {
+	local SAVED_NAME=saved_acl2
+	sed -e "s:${S}:/usr/share/acl2:g" -i ${SAVED_NAME} || die
+	dobin ${SAVED_NAME}
+
+	insinto /usr/share/acl2
+	doins ${SAVED_NAME}.core
+	if use books; then
+		sed -e "/5/a export ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/" \
+			-i ${SAVED_NAME} || die
+		doins -r books
+	fi
+
+	DOCS=( books/README.md )
+	if use doc; then
+		HTML_DOCS=( doc/HTML/. )
+	fi
+	einstalldocs
+
+	if use emacs; then
+		elisp-install ${PN} emacs/*{.el,elc}
+		doins TAGS
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/sci-mathematics/acl2/files/acl2-use_make_variable.patch
+++ b/sci-mathematics/acl2/files/acl2-use_make_variable.patch
@@ -1,0 +1,13 @@
+use make variable to avoid QA issue: "make[1]: warning: jobserver unavailable: using -j1.  Add '+' to parent make rule"
+
+--- a/GNUmakefile
++++ b/GNUmakefile
+@@ -576,7 +576,7 @@ doc/home-page.html: doc/home-page.lisp
+ # xdoc::save that populates doc/manual/ (not under books/).
+ acl2-manual: check-books
+ 	rm -rf doc/manual books/system/doc/acl2-manual.cert
+-	cd books ; make USE_QUICKLISP=1 system/doc/acl2-manual.cert
++	cd books ; $(MAKE) USE_QUICKLISP=1 system/doc/acl2-manual.cert
+ 	rm -rf doc/manual/download/*
+ 
+ # WARNING: The dependency list just below isn't complete, since it

--- a/sci-mathematics/acl2/metadata.xml
+++ b/sci-mathematics/acl2/metadata.xml
@@ -20,6 +20,6 @@
 		<flag name="books">build community books, the canonical collection of open-source libraries</flag>
 	</use>
 	<upstream>
-		<remote-id type="github">acl2-devel/acl2-devel</remote-id>
+		<remote-id type="github">acl2/acl2</remote-id>
 	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
* EAPI bump
* Remove eutils because it is no longer necessary and deprecated
* inherit elisp-common for compiling/installing emacs files
* Add emacs use flag for emacs files and TAGS file
* Add app-editor/emacs to BDEPEND if its needed during compilation
* Add doc use flag for compiling and installing html docs
* Add dev-lang/perl as a DEPEND for doc
* Change SRC_URI to upstream and updated github
* Update metadata.xml to this new SRC_URI
* Add patch which changes `make` to $(MAKE) in GNUmakefile for Q/A
* Add src_prepare which deletes *.bak, *.orig, and sparc binary acl2link
* Remove `emake certify-books` because certify-books no longer exists
* Add `emake basic` because it is the one which is the default [1]
* emake basic is much faster so the einfos are removed
* Add `emake DOC` to compilation phase if DOC use flag is enabled
* Add `elisp-compile` to compilation phase if emacs use flag is enabled
* Install README.md always and html docs if doc use flag is enabled
* Install emacs files and TAGS file is emacs use flag is enabled
* Add `use emacs && elisp-site-regen` to postinst() and postrm() phases

Currently, sci-mathematics/acl2 will not always install successfully.
This is because the TAGS file is only created if the etags program is
installed. The etags program is installed when emacs is
installed. Therefore, an emacs use flag is added so the TAGS file is
installed only when it is enabled. Since app-editors/emacs is required
for the CBUILD, the dependency is added to the BDEPEND. In order to
compile/install emacs files, the elisp-common eclass is inherited.
This compilation and installation only takes place if the emacs use
flag is enabled. The `elisp-site-regen` is added to pkg_postinst() and
pkg_postrm() with the requirement of the emacs use flag being enabled.
If the doc flag is enabled, then `emake DOC` is executed and the html
docs are installed; however, the README.md is always installed. Since
dev-lang/perl is needed for this compilation, it is added as a
conditional requirement. If the books use flag is enabled, then the
books will be compiled using `emake basic`. The reason `emake basic`
was chosen instead of `emake regression` is because the latter is
stated as being "usually unnecessary" [1] and that "most users will not
want to use this target" [2] while the former is the default [1]
and stated as "a convenient starting place" [3]. Every book is made
before for major releases, so it is unecessary to to build all for an
install. Since the compilation of the books is much faster, the einfo
messages are removed. In addition, the SRC_URI for the previous ebuild
is behind in commits [4] and is simply a clone. Therefore, the main
github repo replaced it. The metadata is updated to this change also.
A src_prepare phase was added which copies debian's Changelog of this
package [5]. The entry on 2015-10-21 of this Changelog shows that
the *.bak and *.orig files were removed to clean the target. Also,
the inadvertent sparc binary acl2link was removed. This sparc binary
lacks source code and therefore violates the GNU GPL. Debian filed a
bug about this binary and the solution was to delete it [6].
A patch is added so a Q/A warning is not given: "make[1]: warning:
jobserver unavailable: using -j1.  Add '+' to parent make rule".
The patch changes a make command to use the variable $(MAKE). This
patch will be made available upstream via a github pull request.
Finally, eutils is removed due to being depreciated and the EAPI is
bumped.

[1] https://www.cs.utexas.edu/users/moore/acl2/v8-3/combined-manual/
index.html?topic=ACL2____BOOKS-CERTIFICATION
[2] https://github.com/acl2/acl2/blob/8.3/books/GNUmakefile#L61
[3] https://github.com/acl2/acl2/blob/8.3/books/GNUmakefile#L48
[4] https://github.com/acl2-devel/acl2-devel
[5] https://debian.pkgs.org/9/debian-main-arm64/
acl2_7.2dfsg-3_arm64.deb.html
[6] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=787368

Closes: https://bugs.gentoo.org/755368
Package-Manager: Portage-3.0.20, Repoman-3.0.2
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>