### PR TITLE
sci-misc/irstlm: remove AM_CXXFLAGS, add doc/static-libs use flags

### DIFF
--- a/sci-misc/irstlm/files/irstlm-6.00.05-doc-obey-docdir.patch
+++ b/sci-misc/irstlm/files/irstlm-6.00.05-doc-obey-docdir.patch
@@ -1,0 +1,22 @@
+Remove doc/irstlm-manual.pdf from install in --prefix to instead obey --docdir
+
+--- a/doc/Makefile.am
++++ b/doc/Makefile.am
+@@ -1,5 +1,3 @@
+-documentationdir = @prefix@/doc
+-
+ if DOC_COMPILATION
+ 
+ irstlm-manual.pdf: irstlm-manual.tex
+@@ -14,10 +12,6 @@ clean-local:
+ 
+ all: irstlm-manual.pdf
+  
+-dist_documentation_SCRIPTS = irstlm-manual.pdf
++dist_doc_DATA = irstlm-manual.pdf
+ 
+ endif
+-
+-EXTRA_DIST = irstlm-manual.tex 
+-
+-

--- a/sci-misc/irstlm/files/irstlm-6.00.05-remove-lib-linking.patch
+++ b/sci-misc/irstlm/files/irstlm-6.00.05-remove-lib-linking.patch
@@ -1,0 +1,18 @@
+Remove Makefile.am lib linking operation
+Taken from upstream PR: https://github.com/irstlm-team/irstlm/pull/12
+
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -7,12 +7,3 @@ SUBDIRS = src scripts doc
+ EXTRA_DIST = README RELEASE Copyright
+ 
+ ACLOCAL_AMFLAGS = -I m4
+-
+-LN_S=@LN_S@
+-
+-install-exec-hook:
+-	cd ${exec_prefix}/ && \
+-	  ${LN_S} -n -f lib lib64
+-
+-dist-hook:
+-	rm -rf `find $(distdir)/doc -type d -name .svn`

--- a/sci-misc/irstlm/irstlm-6.00.05-r1.ebuild
+++ b/sci-misc/irstlm/irstlm-6.00.05-r1.ebuild
@@ -1,0 +1,38 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="A tool to estimate, store, and access very large n-gram language models"
+HOMEPAGE="https://hlt-mt.fbk.eu/technologies/irstlm"
+SRC_URI="https://github.com/irstlm-team/${PN}/archive/v${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="LGPL-3"
+SLOT="0"
+KEYWORDS="~amd64"
+IUSE="doc static-libs"
+
+BDEPEND="doc? ( app-text/texlive[extra] )"
+
+PATCHES=(
+	"${FILESDIR}"/${P}-remove-lib-linking.patch
+	"${FILESDIR}"/${P}-doc-obey-docdir.patch
+)
+
+src_prepare() {
+	default
+	# Remove AM_CXXFLAGS that are breaking the package or should not be there
+	# Bug: https://bugs.gentoo.org/755473
+	sed -e 's/-static -isystem\/usr\/include -W //' -i src/Makefile.am
+	# Needed for doc
+	cp "${S}/doc/RELEASE" "${S}/RELEASE.tex"
+	eautoreconf
+}
+
+src_configure() {
+	econf \
+		$(use_enable static-libs static) \
+		$(use_enable doc)
+}


### PR DESCRIPTION
* EAPI bump
* Add doc and static-libs use flags
* Add app-text/texlive[extra] as BDEPEND for doc
* Add patch that removes lib and lib64 linking
* Add patch that makes irstlm-manual.pdf obey --docdir
* Remove AM_CXXFLAGS that breaks the package or should not be there
* Copy doc/RELEASE to RELEASE.tex for doc
* Add static-libs and doc to the configure using the econf variable

Currently, sci-misc/irstlm will not compile due to bad AM_CXXFLAGS.
A sed command was added which removes these unwanted flags. This was
done in the same way to a PR upstream [1]. In addition, a patch was
added which removes a Makefile.am lib->lib64 linking operation. This
was also done in the same way as the upstream PR [1]. Another patch was
added which removes doc/irstlm-manual.pdf from install in --prefix to
instead obey --docdir. Furthermore, the doc USE flag was added for this
new documentation. To create this documentation, a simple copy command
of doc/RELEASE to RELEASE.tex is needed for it to make correctly. Also,
a BDEPEND of app-text/texlive[extra] was added if the doc USE is true.
A static-libs USE flag was added to include the static library
libirstlm.a. Both USE flags are configured in the econf variable.
Finally, the EAPI was bumped.

[1] https://github.com/irstlm-team/irstlm/pull/12

Closes: https://bugs.gentoo.org/755473
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>