### PR TITLE
sci-mathematics/acl2: Require >=dev-lisp/sbcl-1.5.2 in BDEPEND 

### DIFF
--- a/sci-mathematics/acl2/acl2-8.3.ebuild
+++ b/sci-mathematics/acl2/acl2-8.3.ebuild
@@ -1,51 +1,86 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
-inherit eutils
+inherit elisp-common
 
 DESCRIPTION="Industrial strength theorem prover"
 HOMEPAGE="https://www.cs.utexas.edu/users/moore/acl2/"
-MY_PN=${PN}-devel
-SRC_URI="https://github.com/${MY_PN}/${MY_PN}/releases/download/${PV}/${P}.tar.gz"
+SRC_URI="https://github.com/acl2/acl2/archive/${PV}/${P}.tar.gz"
 
 SLOT="0"
 LICENSE="BSD"
 KEYWORDS="~amd64 ~x86"
-IUSE="books"
+IUSE="books doc emacs"
 
-BDEPEND="dev-lisp/sbcl"
+BDEPEND="
+	dev-lisp/sbcl
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
 DEPEND="
 	dev-lisp/sbcl:=
 	books? ( dev-lang/perl )
+	doc? ( dev-lang/perl )
 "
 RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-use_make_variable.patch )
+
+src_prepare() {
+	find . -type f -name "*.bak" -delete
+	find . -type f -name "*.orig" -delete
+	# Remove sparc binary inadvertently included in upstream
+	rm books/workshops/2003/schmaltz-al-sammane-et-al/support/acl2link || die
+	default
+}
 
 src_compile() {
 	emake LISP="sbcl --noinform --noprint \
 		--no-sysinit --no-userinit --disable-debugger"
 
 	if use books; then
-		echo
-		einfo "Building certificates ..."
-		einfo "(this may take hours to finish)"
-		emake certify-books
+		emake "ACL2=${S}/saved_acl2" basic
+	fi
+
+	if use doc; then
+		emake "ACL2=${S}/saved_acl2" DOC
+	fi
+
+	if use emacs; then
+		elisp-compile emacs/*.el
 	fi
 }
 
 src_install() {
-	SAVED_NAME=saved_acl2
+	local SAVED_NAME=saved_acl2
 	sed -e "s:${S}:/usr/share/acl2:g" -i ${SAVED_NAME} || die
-	if use books; then
-		sed -e "/5/a export ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/" \
-			-i ${SAVED_NAME} || die
-	fi
 	dobin ${SAVED_NAME}
 
 	insinto /usr/share/acl2
-	doins TAGS ${SAVED_NAME}.core
+	doins ${SAVED_NAME}.core
 	if use books; then
+		sed -e "/5/a export ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/" \
+			-i ${SAVED_NAME} || die
 		doins -r books
 	fi
+
+	DOCS=( books/README.md )
+	if use doc; then
+		HTML_DOCS=( doc/HTML/. )
+	fi
+	einstalldocs
+
+	if use emacs; then
+		elisp-install ${PN} emacs/*{.el,elc}
+		doins TAGS
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
 }

--- a/sci-mathematics/acl2/acl2-8.4.ebuild
+++ b/sci-mathematics/acl2/acl2-8.4.ebuild
@@ -15,7 +15,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="books doc emacs"
 
 BDEPEND="
-	dev-lisp/sbcl
+	>=dev-lisp/sbcl-1.5.2
 	emacs? ( >=app-editors/emacs-23.1:* )
 "
 DEPEND="


### PR DESCRIPTION
* Require >=dev-lisp/sbcl-1.5.2 due to addition of "--tls-limit 16384"

Currently, sci-mathematics/acl2-8.4 will not compile with the current
stable dev-lisp/sbcl-1.4.9 due to the addition of "--tls-limit 16384"
to sbcl within the created file saved_acl2. This addition is documented
in the acl-8.4 release notes [1] as "Increased the number of special
variables that can be created". Within sbcl, this new feature was added
in version 1.5.2. The news for that version [2] reads "enhancement:
command-line option '--tls-limit' can be used". Therefore attempting
to use the argument "--tls-limit 16384" with sbcl versions prior to
1.5.2 causes it to fail. Thus a minimum version requirement is needed
for acl2-8.4.

[1] https://www.cs.utexas.edu/users/moore/acl2/v8-4/combined-manual/
index.html?topic=ACL2____NOTE-8-4
[2] http://www.sbcl.org/all-news.html

Closes: #1113 
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>