### PR TITLE
sci-mathematics/acl2: Fix sed expression, clearer books install

### DIFF
--- a/sci-mathematics/acl2/acl2-8.3-r2.ebuild
+++ b/sci-mathematics/acl2/acl2-8.3-r2.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit elisp-common
+
+DESCRIPTION="Industrial strength theorem prover"
+HOMEPAGE="https://www.cs.utexas.edu/users/moore/acl2/"
+SRC_URI="https://github.com/acl2/acl2/archive/${PV}/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64 ~x86"
+IUSE="books doc emacs"
+
+BDEPEND="
+	dev-lisp/sbcl
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+DEPEND="
+	dev-lisp/sbcl:=
+	books? ( dev-lang/perl )
+	doc? ( dev-lang/perl )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-use_make_variable.patch )
+
+src_prepare() {
+	find . -type f -name "*.bak" -delete
+	find . -type f -name "*.orig" -delete
+	# Remove sparc binary inadvertently included in upstream
+	rm books/workshops/2003/schmaltz-al-sammane-et-al/support/acl2link || die
+	default
+}
+
+src_compile() {
+	emake LISP="sbcl --noinform --noprint \
+		--no-sysinit --no-userinit --disable-debugger"
+
+	if use books; then
+		emake "ACL2=${S}/saved_acl2" basic
+	fi
+
+	if use doc; then
+		emake "ACL2=${S}/saved_acl2" DOC
+	fi
+
+	if use emacs; then
+		elisp-compile emacs/*.el
+	fi
+}
+
+src_install() {
+	local SAVED_NAME=saved_acl2
+	sed -e "s:${S}:/usr/share/acl2:g" -i ${SAVED_NAME} || die
+	if use books; then
+		sed -e "5iexport ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/" \
+			-i ${SAVED_NAME} || die
+	fi
+	dobin ${SAVED_NAME}
+
+	insinto /usr/share/acl2
+	doins ${SAVED_NAME}.core
+
+	if use books; then
+		doins -r books
+	fi
+
+	DOCS=( books/README.md )
+	if use doc; then
+		HTML_DOCS=( doc/HTML/. )
+	fi
+	einstalldocs
+
+	if use emacs; then
+		elisp-install ${PN} emacs/*{.el,elc}
+		doins TAGS
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}

--- a/sci-mathematics/acl2/acl2-8.4-r1.ebuild
+++ b/sci-mathematics/acl2/acl2-8.4-r1.ebuild
@@ -1,0 +1,89 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit elisp-common
+
+DESCRIPTION="Industrial strength theorem prover"
+HOMEPAGE="https://www.cs.utexas.edu/users/moore/acl2/"
+SRC_URI="https://github.com/acl2/acl2/archive/${PV}/${P}.tar.gz"
+
+SLOT="0"
+LICENSE="BSD"
+KEYWORDS="~amd64 ~x86"
+IUSE="books doc emacs"
+
+BDEPEND="
+	>=dev-lisp/sbcl-1.5.2
+	emacs? ( >=app-editors/emacs-23.1:* )
+"
+DEPEND="
+	dev-lisp/sbcl:=
+	books? ( dev-lang/perl )
+	doc? ( dev-lang/perl )
+"
+RDEPEND="${DEPEND}"
+
+PATCHES=( "${FILESDIR}"/${PN}-use_make_variable.patch )
+
+src_prepare() {
+	find . -type f -name "*.bak" -delete
+	find . -type f -name "*.orig" -delete
+	# Remove sparc binary inadvertently included in upstream
+	rm books/workshops/2003/schmaltz-al-sammane-et-al/support/acl2link || die
+	default
+}
+
+src_compile() {
+	emake LISP="sbcl --noinform --noprint \
+		--no-sysinit --no-userinit --disable-debugger"
+
+	if use books; then
+		emake "ACL2=${S}/saved_acl2" basic
+	fi
+
+	if use doc; then
+		emake "ACL2=${S}/saved_acl2" DOC
+	fi
+
+	if use emacs; then
+		elisp-compile emacs/*.el
+	fi
+}
+
+src_install() {
+	local SAVED_NAME=saved_acl2
+	sed -e "s:${S}:/usr/share/acl2:g" -i ${SAVED_NAME} || die
+	if use books; then
+		sed -e "5iexport ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/" \
+			-i ${SAVED_NAME} || die
+	fi
+	dobin ${SAVED_NAME}
+
+	insinto /usr/share/acl2
+	doins ${SAVED_NAME}.core
+
+	if use books; then
+		doins -r books
+	fi
+
+	DOCS=( books/README.md )
+	if use doc; then
+		HTML_DOCS=( doc/HTML/. )
+	fi
+	einstalldocs
+
+	if use emacs; then
+		elisp-install ${PN} emacs/*{.el,elc}
+		doins TAGS
+	fi
+}
+
+pkg_postinst() {
+	use emacs && elisp-site-regen
+}
+
+pkg_postrm() {
+	use emacs && elisp-site-regen
+}


### PR DESCRIPTION
* Fix sed expression which does not execute at all
* Move books down to original install location

Currently, the sed expression
`/5/a export ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/` does not modify
the acl2 executable script. The sed expression's intended behavior
seems to be adding the enviroment variable `ACL2_SYSTEM_BOOKS` to the
fifth line on the final script; however, no modification is made.
A new sed expression must replace it, namely
`5iexport ACL2_SYSTEM_BOOKS=/usr/share/acl2/books/` which accomplishes
inserting the enviroment variable into the script. This enviroment
variable is recommended when the books directory resides outside
where the executable was built [1].
In addition, the command `doins -r books` should be moved further down
for the sake of clarity. This way the src_install() function modifies
the files at the top and installs them at the bottom. Also, now
the command `doins -r books` is beside the other similar commands.

[1] https://raw.githubusercontent.com/acl2/acl2/master/doc.lisp

Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>