### PR TITLE
sci-libs/libmatheval: EAPI bump, static-libs USE, fix build scripts

### DIFF
--- a/sci-libs/libmatheval/files/libmatheval-1.1.11_update_configure.ac.patch
+++ b/sci-libs/libmatheval/files/libmatheval-1.1.11_update_configure.ac.patch
@@ -1,0 +1,40 @@
+Update configure.ac build script
+Remove references to guile which is only used for tests and breaks the package due to needing masked guile-1*
+sed command in ebuild removes references to these tests
+Taken from git repo which has updated the package: https://gitlab.com/Grimler/libmatheval/-/blob/master/configure.ac
+
+--- a/configure.ac
++++ b/configure.ac
+@@ -21,10 +21,8 @@ dnl Process this file with autoconf to produce a configure script.
+ AC_PREREQ(2.53)
+ AC_INIT([libmatheval],[1.1.11],[asamardzic@gnu.org])
+ AC_CONFIG_AUX_DIR([config])
+-AC_CONFIG_MACRO_DIR([m4])
+-AC_SUBST([ac_aux_dir])
+-AM_INIT_AUTOMAKE([libmatheval], [1.1.11])
+-AC_CONFIG_SRCDIR([configure.in])
++AC_CONFIG_MACRO_DIRS([m4])
++AM_INIT_AUTOMAKE
+ AM_CONFIG_HEADER([config.h])
+ 
+ dnl Initialize the test suite.
+@@ -44,7 +42,6 @@ AC_PROG_LIBTOOL
+ AC_PROG_MAKE_SET
+ AC_PROG_YACC
+ AM_MISSING_PROG([AUTOM4TE], [autom4te])
+-GUILE_FLAGS
+ 
+ dnl Checks for libraries.
+ 
+@@ -59,11 +56,5 @@ AC_TYPE_SIZE_T
+ dnl Checks for library functions.
+ AC_CHECK_FUNCS([bzero memset], [break])
+ 
+-dnl Additional Guile feature checks.
+-AC_CHECK_TYPE([scm_t_bits], [AC_DEFINE([HAVE_SCM_T_BITS], [1], [Define to 1 if you have the `scm_t_bits' type.])], [], [#include <libguile.h>])
+-AC_CHECK_LIB([guile], [scm_c_define_gsubr], [AC_DEFINE([HAVE_SCM_C_DEFINE_GSUBR], [1], [Define to 1 if you have the `scm_c_define_gsubr' function.])], [], [$GUILE_LDFLAGS])
+-AC_CHECK_LIB([guile], [scm_make_gsubr], [AC_DEFINE([HAVE_SCM_MAKE_GSUBR], [1], [Define to 1 if you have the `scm_make_gsubr' function.])], [], [$GUILE_LDFLAGS])
+-AC_CHECK_LIB([guile], [scm_num2dbl], [AC_DEFINE([HAVE_SCM_NUM2DBL], [1], [Define to 1 if you have the `scm_num2dbl' function.])], [], [$GUILE_LDFLAGS])
+-
+ AC_CONFIG_FILES([Makefile doc/Makefile lib/Makefile])
+ AC_OUTPUT(libmatheval.pc)

--- a/sci-libs/libmatheval/libmatheval-1.1.11-r1.ebuild
+++ b/sci-libs/libmatheval/libmatheval-1.1.11-r1.ebuild
@@ -1,0 +1,32 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+inherit autotools
+
+DESCRIPTION="library to parse and evaluate symbolic expressions"
+HOMEPAGE="https://www.gnu.org/software/libmatheval/"
+SRC_URI="mirror://gnu/${PN}/${P}.tar.gz"
+
+LICENSE="GPL-3+"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+IUSE="static-libs"
+
+PATCHES=( "${FILESDIR}"/"${P}"_update_configure.ac.patch  )
+
+src_prepare() {
+	# rename configure.in -> configure.ac for Q/A
+	mv configure.in configure.ac || die
+	# patch configure.ac
+	default
+	# remove test subdirectory depends on masked guile-1*
+	# Bug: https://bugs.gentoo.org/755353
+	sed -e 's/SUBDIRS = doc lib tests/SUBDIRS = doc lib/' -i Makefile.am || die
+	eautoreconf
+}
+
+src_configure() {
+	econf $(use_enable static-libs static)
+}


### PR DESCRIPTION
* EAPI bump
* inherit autotools for regenerating the build scripts
* ${PF} -> ${P} in SRC_URI
* LICENSE is actually GPL-3+ [1]
* Add and implement static-libs USE flag
* Rename configure.in -> configure.ac for Q/A
* Add patch to update configure.ac and remove references to guile
* Remove tests directory in Makefile.am which depends on masked guile-1*
* Regenerate build scripts with autoreconf

Currently, sci-libs/libmatheval will not compile due to depending on
the masked dev-scheme/guile-1* while compiling tests in the
tests/ directory. The was fixed by removing the tests/ directory from
SUBDIRS in Makefile.am. All references to guile was removed from the
renamed configure.in -> configure.ac build script. This script was
updated using an upstream git repo which updates the package [2].
Finally, the EAPI was bumped, ${PF} -> ${P} in SRC_URI, static-libs
USE implemented, and LICENSE changed to the actual license.

[1] https://www.gnu.org/software/libmatheval/manual/libmatheval.html
[2] https://gitlab.com/Grimler/libmatheval/-/tree/master/

Closes: https://bugs.gentoo.org/755353
Package-Manager: Portage-3.0.20, Repoman-3.0.3
Signed-off-by: Lucas Mitrak <lucas@lucasmitrak.com>