### PR TITLE
sci-misc/elmer-fem: Fix compile error

### DIFF
--- a/sci-misc/elmer-fem/elmer-fem-9.0-r1.ebuild
+++ b/sci-misc/elmer-fem/elmer-fem-9.0-r1.ebuild
@@ -1,0 +1,76 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=8
+
+FORTRAN_STANDARD=90
+
+inherit fortran-2 flag-o-matic cmake multilib
+
+ELMER_ROOT="elmerfem"
+MY_PN=${PN/elmer-/}
+
+DESCRIPTION="Finite element programs, libraries, and visualization tools"
+HOMEPAGE="https://www.csc.fi/web/elmer http://www.elmerfem.org/blog/"
+SRC_URI="https://github.com/ElmerCSC/elmerfem/archive/release-${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-2"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="ice gui matc mumps mpi post test"
+RESTRICT="!test? ( test )"
+
+RDEPEND="
+	virtual/blas
+	virtual/lapack
+	sci-libs/arpack
+	mumps? ( sci-libs/mumps )
+	mpi? ( sys-cluster/openmpi )
+	post? (
+		dev-lang/tcl:0=
+		dev-lang/tk:0=
+	)
+	gui? ( x11-libs/qwt:6 )
+"
+DEPEND="${RDEPEND}"
+# Note this seems to only configure correctly with the elmer version of umfpack
+# But this doesn't stop it from compiling / working without it
+
+PATCHES=(
+	"${FILESDIR}/${PN}-DCRComplexSolve-compile-error.patch"
+	"${FILESDIR}/${PN}-ElmerIce-compile.patch"
+)
+
+S="${WORKDIR}/elmerfem-release-${PV}"
+
+src_prepare() {
+	cmake_src_prepare
+	sed -i '/#include <QPainter>/a #include <QPainterPath>' ElmerGUI/Application/twod/renderarea.cpp || die
+	test-flag-FC -fallow-argument-mismatch && append-fflags -fallow-argument-mismatch
+	test-flag-FC -fallow-invalid-boz && append-fflags -fallow-invalid-boz
+	# TODO: fix the tests, fails in compile phase: multiple rules to make target
+	rm -r fem/tests/* || die
+	touch fem/tests/CMakeLists.txt || die
+}
+
+src_configure() {
+	local mycmakeargs=(
+		-DMPI_Fortran_COMPILE_FLAGS="$FCFLAGS"
+		-DCMAKE_Fortran_FLAGS="$FCFLAGS"
+		-DELMER_INSTALL_LIB_DIR="/usr/$(get_libdir)/elmersolver"
+		-DWITH_MPI="$(usex mpi)"
+		-DWITH_OpenMP="$(usex mpi)"
+		-DWITH_MATC="$(usex matc)"
+		-DWITH_Mumps="$(usex mumps)"
+		-DWITH_ElmerIce="$(usex ice)"
+		-DWITH_ELMERPOST="$(usex post)"
+		-DWITH_ELMERGUI="$(usex gui)"
+		-DWITH_QT5="$(usex gui)"
+		-DWITH_QWT="$(usex gui)"
+		-DQWT_INCLUDE_DIR="/usr/include/qwt6"
+		-DQWT_LIBRARY="/usr/$(get_libdir)/libqwt6-qt5.so"
+		-DBUILD_TESTING="$(usex test)"
+	)
+	cmake_src_configure
+}

--- a/sci-misc/elmer-fem/files/elmer-fem-DCRComplexSolve-compile-error.patch
+++ b/sci-misc/elmer-fem/files/elmer-fem-DCRComplexSolve-compile-error.patch
@@ -1,0 +1,70 @@
+From 8ea87194fb50ff052a75212f9d2a2ae217edad95 Mon Sep 17 00:00:00 2001
+From: Mathias <mathias@localhost.localdomain>
+Date: Sun, 2 May 2021 12:06:15 +0200
+Subject: [PATCH] fixed DCRComplexSolve compile error
+
+---
+ fem/src/modules/DCRComplexSolve.F90 | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+diff --git a/fem/src/modules/DCRComplexSolve.F90 b/fem/src/modules/DCRComplexSolve.F90
+index cfa71dee..b6bb59bc 100644
+--- a/fem/src/modules/DCRComplexSolve.F90
++++ b/fem/src/modules/DCRComplexSolve.F90
+@@ -426,7 +426,7 @@ CONTAINS
+    SUBROUTINE InputTensor( Tensor, IsScalar, Name, Material, n, NodeIndexes )
+ !------------------------------------------------------------------------------
+       REAL(KIND=dp) :: Tensor(:,:,:)
+-      INTEGER :: n, NodeIndexes(:)
++      INTEGER :: n, i, j, NodeIndexes(:)
+       LOGICAL :: IsScalar
+       CHARACTER(LEN=*) :: Name
+       TYPE(ValueList_t), POINTER :: Material
+@@ -485,7 +485,7 @@ CONTAINS
+    SUBROUTINE InputVector( Tensor, IsScalar, Name, Material, n, NodeIndexes )
+ !------------------------------------------------------------------------------
+       REAL(KIND=dp) :: Tensor(:,:)
+-      INTEGER :: n, NodeIndexes(:)
++      INTEGER :: n, i, NodeIndexes(:)
+       LOGICAL :: IsScalar
+       CHARACTER(LEN=*) :: Name
+       TYPE(ValueList_t), POINTER :: Material
+@@ -543,7 +543,7 @@ CONTAINS
+     REAL(KIND=dp) :: DiffCoef(3,3), Velo(3)
+     COMPLEX(KIND=dp) :: LSTIFF(2*n,2*n), LFORCE(2*n), A
+     LOGICAL :: Stat
+-    INTEGER :: i,p,q,t,dim, NBasis, CoordSys
++    INTEGER :: i,j,p,q,t,dim, NBasis, CoordSys
+     TYPE(GaussIntegrationPoints_t) :: IntegStuff
+ 
+     REAL(KIND=dp) :: X,Y,Z,Metric(3,3),SqrtMetric,Symb(3,3,3),dSymb(3,3,3,3)
+@@ -678,7 +678,7 @@ CONTAINS
+          C1(3), C0
+     COMPLEX(KIND=dp) :: LSTIFF(n,n), LFORCE(n), A
+     LOGICAL :: Stat
+-    INTEGER :: i,p,q,t,dim,CoordSys
++    INTEGER :: i,j,p,q,t,dim,CoordSys
+     TYPE(GaussIntegrationPoints_t) :: IntegStuff
+ !------------------------------------------------------------------------------
+     dim = CoordinateSystemDimension()
+@@ -1374,7 +1374,7 @@ contains
+    SUBROUTINE InputTensor( Tensor, IsScalar, Name, Material, n, NodeIndexes )
+ !------------------------------------------------------------------------------
+       REAL(KIND=dp) :: Tensor(:,:,:)
+-      INTEGER :: n, NodeIndexes(:)
++      INTEGER :: n, i, NodeIndexes(:)
+       LOGICAL :: IsScalar
+       CHARACTER(LEN=*) :: Name
+       TYPE(ValueList_t), POINTER :: Material
+@@ -1426,7 +1426,7 @@ contains
+    SUBROUTINE InputVector( Tensor, IsScalar, Name, Material, n, NodeIndexes )
+ !------------------------------------------------------------------------------
+       REAL(KIND=dp) :: Tensor(:,:)
+-      INTEGER :: n, NodeIndexes(:)
++      INTEGER :: n, i, NodeIndexes(:)
+       LOGICAL :: IsScalar
+       CHARACTER(LEN=*) :: Name
+       TYPE(ValueList_t), POINTER :: Material
+-- 
+2.31.1
+

--- a/sci-misc/elmer-fem/metadata.xml
+++ b/sci-misc/elmer-fem/metadata.xml
@@ -12,6 +12,7 @@
 		<flag name="gui">Build the ElmerGUI</flag>
 		<flag name="matc">Build the Elmer matc library</flag>
 		<flag name="ice">Build ElmerICE</flag>
+		<flag name="mumps">Build with Mumps</flag>
 		<flag name="post">Build ElmerPOST</flag>
 	</use>
 </pkgmetadata>


### PR DESCRIPTION
Hi

This pull request fixes a compile error associated with issue
[#274](https://github.com/ElmerCSC/elmerfem/issues/274).

I've added the patch attached to this issue as well as the following:

 - Exposed a useflag for WITH_Mumps
 - removed the softblock on arpack by changing the
    ELMER_INSTALL_LIB_DIR to `/usr/$(get_libdir)/elmersover`
    This location matches the cmake file from upstream and prevents
    a collision with system arpack.

Package-Manager: Portage-3.0.28, Repoman-3.0.3