### PR TITLE
sci-libs/pytorch: fix python build with >=setuptools-59.6

### DIFF
--- a/sci-libs/pytorch/files/pytorch-1.10.0-fix-distutils.patch
+++ b/sci-libs/pytorch/files/pytorch-1.10.0-fix-distutils.patch
@@ -1,0 +1,93 @@
+This fix distutils-r1_src_install failure with setuptools-59
+
+From 9af2edb158b3603c44eff6e12896f1d215e8b898 Mon Sep 17 00:00:00 2001
+From: Nikita Shulga <nshulga@fb.com>
+Date: Tue, 14 Dec 2021 07:15:34 -0800
+Subject: [PATCH] Properly import LooseVersion
+
+This fixes regression introduced by https://github.com/pytorch/pytorch/pull/57040
+
+Somehow importing `distutils` from `setuptool` caused import of
+`distutils.versions`, which is not a documented dependency and got
+change with the release of
+[setuptools-59.6.0](https://github.com/pypa/setuptools/tree/v59.6.0)
+We should not rely on that, as
+`import distutils` never re-imports `distutils.version`, which one can
+see by observing
+https://github.com/python/cpython/blob/3.9/Lib/distutils/__init__.py
+or by running:
+```
+% python3 -c "import distutils;print(distutils.__version__, dir(distutils))"
+3.7.5 ['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', 'sys']
+% python3 -c "from setuptools import distutils;print(distutils.__version__, dir(distutils))"
+3.7.5 ['__builtins__', '__cached__', '__doc__', '__file__', '__loader__', '__name__', '__package__', '__path__', '__spec__', '__version__', 'archive_util', 'ccompiler', 'cmd', 'config', 'core', 'debug', 'dep_util', 'dir_util', 'dist', 'errors', 'extension', 'fancy_getopt', 'file_util', 'filelist', 'log', 'spawn', 'sys', 'sysconfig', 'util', 'version']
+```
+---
+ test/run_test.py                                      | 4 ++--
+ tools/setup_helpers/cmake.py                          | 8 ++++----
+ torch/testing/_internal/common_methods_invocations.py | 8 ++++----
+ 3 files changed, 10 insertions(+), 10 deletions(-)
+
+diff --git a/tools/setup_helpers/cmake.py b/tools/setup_helpers/cmake.py
+index 01e87b4bca879..686b5c4a34f4c 100644
+--- a/tools/setup_helpers/cmake.py
++++ b/tools/setup_helpers/cmake.py
+@@ -8,7 +8,7 @@
+ from subprocess import check_call, check_output, CalledProcessError
+ import sys
+ import sysconfig
+-from setuptools import distutils  # type: ignore[import]
++from distutils.version import LooseVersion
+ from typing import IO, Any, Dict, List, Optional, Union, cast
+ 
+ from . import which
+@@ -120,10 +120,10 @@ def _get_cmake_command() -> str:
+             return cmake_command
+         cmake3 = which('cmake3')
+         cmake = which('cmake')
+-        if cmake3 is not None and CMake._get_version(cmake3) >= distutils.version.LooseVersion("3.10.0"):
++        if cmake3 is not None and CMake._get_version(cmake3) >= LooseVersion("3.10.0"):
+             cmake_command = 'cmake3'
+             return cmake_command
+-        elif cmake is not None and CMake._get_version(cmake) >= distutils.version.LooseVersion("3.10.0"):
++        elif cmake is not None and CMake._get_version(cmake) >= LooseVersion("3.10.0"):
+             return cmake_command
+         else:
+             raise RuntimeError('no cmake or cmake3 with version >= 3.10.0 found')
+@@ -134,7 +134,7 @@ def _get_version(cmd: str) -> Any:
+ 
+         for line in check_output([cmd, '--version']).decode('utf-8').split('\n'):
+             if 'version' in line:
+-                return distutils.version.LooseVersion(line.strip().split(' ')[2])
++                return LooseVersion(line.strip().split(' ')[2])
+         raise RuntimeError('no version found')
+ 
+     def run(self, args: List[str], env: Dict[str, str]) -> None:
+diff --git a/torch/testing/_internal/common_methods_invocations.py b/torch/testing/_internal/common_methods_invocations.py
+index b66e6470b590c..6ec77c2b0ce2e 100644
+--- a/torch/testing/_internal/common_methods_invocations.py
++++ b/torch/testing/_internal/common_methods_invocations.py
+@@ -40,7 +40,7 @@
+      freeze_rng_state)
+ import torch.testing._internal.opinfo_helper as opinfo_helper
+ 
+-from setuptools import distutils
++from distutils.version import LooseVersion
+ 
+ has_scipy_fft = False
+ if TEST_SCIPY:
+@@ -14008,11 +14008,11 @@ def ref_pairwise_distance(input1, input2):
+                    skips=(
+                        # Reference: https://github.com/pytorch/pytorch/pull/49155#issuecomment-742664611
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_extremal',
+-                                    active_if=TEST_SCIPY and distutils.version.LooseVersion(scipy.__version__) < "1.4.0"),
++                                    active_if=TEST_SCIPY and LooseVersion(scipy.__version__) < "1.4.0"),
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_hard',
+-                                    active_if=TEST_SCIPY and distutils.version.LooseVersion(scipy.__version__) < "1.4.0"),
++                                    active_if=TEST_SCIPY and LooseVersion(scipy.__version__) < "1.4.0"),
+                        DecorateInfo(unittest.skip("Skipped!"), 'TestUnaryUfuncs', 'test_reference_numerics_normal',
+-                                    active_if=TEST_SCIPY and distutils.version.LooseVersion(scipy.__version__) < "1.4.0"),
++                                    active_if=TEST_SCIPY and LooseVersion(scipy.__version__) < "1.4.0"),
+                    )),
+     UnaryUfuncInfo('lgamma',
+                    ref=reference_lgamma if TEST_SCIPY else _NOTHING,

--- a/sci-libs/pytorch/pytorch-1.10.1.ebuild
+++ b/sci-libs/pytorch/pytorch-1.10.1.ebuild
@@ -117,6 +117,7 @@ PATCHES=(
 	"${FILESDIR}"/${PN}-1.7.1-no-rpath.patch
 	"${FILESDIR}"/${PN}-1.7.1-torch_shm_manager.patch
 	"${FILESDIR}"/${PN}-1.10.0-nonull.patch
+	"${FILESDIR}"/${PN}-1.10.0-fix-distutils.patch
 )
 
 distutils_enable_tests pytest


### PR DESCRIPTION
Backport an upstream PR: https://github.com/pytorch/pytorch/pull/69904

Bug: https://github.com/gentoo/sci/pull/1123#issuecomment-999597677
Package-Manager: Portage-3.0.22, Repoman-3.0.3
Signed-off-by: Yiyang Wu <xgreenlandforwyy@gmail.com>