### PR TITLE
sci-libs/pytorch fixed thrust include path for rocm platform

### DIFF
--- a/sci-libs/pytorch/pytorch-1.10.1.ebuild
+++ b/sci-libs/pytorch/pytorch-1.10.1.ebuild
@@ -230,6 +230,7 @@ src_prepare() {
 		export PYTORCH_ROCM_ARCH="${AMDGPU_TARGETS}"
 		sed -e "/set(roctracer_INCLUDE_DIRS/s,\${ROCTRACER_PATH}/include,${EPREFIX}/usr/include/roctracer," \
 			-e "/PYTORCH_HIP_HCC_LIBRARIES/s,\${HIP_PATH}/lib,${EPREFIX}/usr/lib/hip/lib," \
+			-e "/set(roctracer_INCLUDE_DIRS/a\  set(thrust_INCLUDE_DIRS ${EPREFIX}/usr/include/rocthrust)" \
 			-e "s,\${ROCTRACER_PATH}/lib,${EPREFIX}/usr/lib64/roctracer," \
 			-e "/READ.*\.info\/version-dev/c\  set(ROCM_VERSION_DEV_RAW ${ROCM_VERSION})" \
 			-i cmake/public/LoadHIP.cmake || die


### PR DESCRIPTION
Before this change when trying to compile with rocm use flag thrust headers would not be found.