### PR TITLE
sci-physics/spheno: Fix toolchain gfortran

### DIFF
--- a/sci-physics/spheno/files/spheno-3.3.8-gfortran.patch
+++ b/sci-physics/spheno/files/spheno-3.3.8-gfortran.patch
@@ -1,28 +1,18 @@
---- a/Makefile	2022-02-16 16:04:19.000000000 +0100
-+++ b/Makefile	2022-02-17 22:13:48.086482293 +0100
-@@ -3,10 +3,10 @@
- # cases NAG's nagfor, gfortran, g95, Lahey's lf95 and Intels ifort
- # Please uncomment the corresponding line
- # F90 = nagfor
--# F90 = gfortran
-+F90 = gfortran
- # F90 = g95
- # F90 = lf95
--F90 = ifort
-+#F90 = ifort
- Model = src
- version = 400.00
- bin/SPheno:
 --- a/src/Makefile	2022-07-20 11:47:44.078639381 +0200
-+++ b/src/Makefile	2022-07-20 11:50:40.553222937 +0200
-@@ -23,8 +23,8 @@
++++ b/src/Makefile	2022-07-22 19:24:00.389938450 +0200
+@@ -9,10 +9,11 @@
+ # options for various compilers
+ #
  
- # gfortran
- ifeq (${F90},gfortran)
-- comp = -c -O -J${Mdir} -I${InDir}
-- LFlagsB = -O  
-+ comp = -c -O -J${Mdir} -I${InDir} ${FFLAGS} ${FCFLAGS} ${CFLAGS}
-+ LFlagsB = -O ${LDFLAGS}
- endif
+-# Intels ifort, default in optimized mode
+-F90 = ifort
+-comp = -c -O -module ${Mdir} -I${InDir} 
+-LFlagsB = -O  
++
++# gentoo toolchain
++F90 = ${F90}
++comp = -c -O -J${Mdir} -I${InDir}  ${FFLAGS} ${FCFLAGS} ${CFLAGS}
++LFlagsB = -O ${LDFLAGS}
  
- # g95 
+ # Intels ifort, debug modus
+ ifeq (${F90},ifortg)

--- a/sci-physics/spheno/spheno-3.3.8.ebuild
+++ b/sci-physics/spheno/spheno-3.3.8.ebuild
@@ -3,12 +3,15 @@
 
 EAPI=8
 
+inherit toolchain-funcs
+
 MY_PN=SPheno
 MY_P=${MY_PN}-${PV}
 
 DESCRIPTION="SPheno stands for S(upersymmetric) Pheno(menology)"
 HOMEPAGE="https://spheno.hepforge.org/"
 SRC_URI="https://spheno.hepforge.org/downloads/?f=${MY_P}.tar.gz"
+S="${WORKDIR}/${MY_P}"
 
 LICENSE="all-rights-reserved"
 RESTRICT="bindist mirror"
@@ -20,12 +23,11 @@ RDEPEND="${DEPEND}"
 
 PATCHES=( "${FILESDIR}"/${P}-gfortran.patch )
 
-S="${WORKDIR}/${MY_P}"
-
 src_compile() {
 	# single thread force needed since fortan mods depend on each other
 	export MAKEOPTS=-j1
-	emake
+	F90=`tc-getFC`
+	emake F90="${F90}"
 }
 
 src_install() {


### PR DESCRIPTION
We should not call gfortran directly.
Instead use `FC` provided by toolchain.

Signed-off-by: Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>