### PR TITLE
sci-physics/rivet: Use ESYSROOT path

### DIFF
--- a/sci-physics/rivet/rivet-3.1.5.ebuild
+++ b/sci-physics/rivet/rivet-3.1.5.ebuild
@@ -62,8 +62,8 @@ src_configure() {
 	PREFIX_YODA=$(yoda-config --prefix) || die
 	PREFIX_FJ=$(fastjet-config --prefix) || die
 	econf \
-		$(usex hepmc2 "--with-hepmc=/usr" "") \
-		$(usex hepmc3 "--with-hepmc3=/usr" "") \
+		$(usex hepmc2 "--with-hepmc=${SYSROOT}/usr" "") \
+		$(usex hepmc3 "--with-hepmc3=${SYSROOT}/usr" "") \
 		--with-yoda=$PREFIX_YODA \
 		--with-fastjet=$PREFIX_FJ
 }

--- a/sci-physics/rivet/rivet-3.1.5.ebuild
+++ b/sci-physics/rivet/rivet-3.1.5.ebuild
@@ -62,10 +62,10 @@ src_configure() {
 	PREFIX_YODA=$(yoda-config --prefix) || die
 	PREFIX_FJ=$(fastjet-config --prefix) || die
 	econf \
-		$(usex hepmc2 "--with-hepmc=${SYSROOT}/usr" "") \
-		$(usex hepmc3 "--with-hepmc3=${SYSROOT}/usr" "") \
-		--with-yoda=$PREFIX_YODA \
-		--with-fastjet=$PREFIX_FJ
+		$(usex hepmc2 "--with-hepmc=${ESYSROOT}/usr" "") \
+		$(usex hepmc3 "--with-hepmc3=${ESYSROOT}/usr" "") \
+		--with-yoda=${PREFIX_YODA} \
+		--with-fastjet=${PREFIX_FJ}
 }
 
 src_install() {

--- a/sci-physics/rivet/rivet-3.1.6.ebuild
+++ b/sci-physics/rivet/rivet-3.1.6.ebuild
@@ -62,8 +62,8 @@ src_configure() {
 	PREFIX_YODA=$(yoda-config --prefix) || die
 	PREFIX_FJ=$(fastjet-config --prefix) || die
 	econf \
-		$(usex hepmc2 "--with-hepmc=/usr" "") \
-		$(usex hepmc3 "--with-hepmc3=/usr" "") \
+		$(usex hepmc2 "--with-hepmc=${SYSROOT}/usr" "") \
+		$(usex hepmc3 "--with-hepmc3=${SYSROOT}/usr" "") \
 		--with-yoda=$PREFIX_YODA \
 		--with-fastjet=$PREFIX_FJ
 }

--- a/sci-physics/rivet/rivet-3.1.6.ebuild
+++ b/sci-physics/rivet/rivet-3.1.6.ebuild
@@ -62,10 +62,10 @@ src_configure() {
 	PREFIX_YODA=$(yoda-config --prefix) || die
 	PREFIX_FJ=$(fastjet-config --prefix) || die
 	econf \
-		$(usex hepmc2 "--with-hepmc=${SYSROOT}/usr" "") \
-		$(usex hepmc3 "--with-hepmc3=${SYSROOT}/usr" "") \
-		--with-yoda=$PREFIX_YODA \
-		--with-fastjet=$PREFIX_FJ
+		$(usex hepmc2 "--with-hepmc=${ESYSROOT}/usr" "") \
+		$(usex hepmc3 "--with-hepmc3=${ESYSROOT}/usr" "") \
+		--with-yoda=${PREFIX_YODA} \
+		--with-fastjet=${PREFIX_FJ}
 }
 
 src_install() {


### PR DESCRIPTION
I think SYSROOT is better here for eg. gentoo prefix.
Or should it be ESYSROOT?

Signed-off-by: Alexander Puck Neuwirth <alexander@neuwirth-informatik.de>