### PR TITLE
numba-0.56.3 dependency on <numpy-1.24

### DIFF
--- a/dev-python/numba/numba-0.56.3.ebuild
+++ b/dev-python/numba/numba-0.56.3.ebuild
@@ -22,7 +22,7 @@ RDEPEND="
 	>=dev-python/llvmlite-0.39.0[${PYTHON_USEDEP}]
 	<=dev-python/llvmlite-0.40.0
 	>=dev-python/numpy-1.18.0[${PYTHON_USEDEP}]
-	<dev-python/numpy-1.23[${PYTHON_USEDEP}]
+	<dev-python/numpy-1.24[${PYTHON_USEDEP}]
 	threads? ( >=dev-cpp/tbb-2021.1 <dev-cpp/tbb-2021.6 )
 "
 BDEPEND="


### PR DESCRIPTION
According to https://numba.readthedocs.io/en/stable/user/installing.html#version-support-information the dependency changed since 0.56.2