### PR TITLE
xgboost-1.3.1 for python3_10

### DIFF
--- a/dev-python/xgboost/xgboost-1.3.1.ebuild
+++ b/dev-python/xgboost/xgboost-1.3.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=7
 
-PYTHON_COMPAT=( python3_{7,8,9} )
+PYTHON_COMPAT=( python3_{7,8,9,10} )
 
 inherit distutils-r1
 


### PR DESCRIPTION
this xgboost version already supports python3.10 no need to update just for pthon_target issues