### PR TITLE
add github remote-id when possible

### DIFF
--- a/app-arch/libdeflate/metadata.xml
+++ b/app-arch/libdeflate/metadata.xml
@@ -8,9 +8,12 @@
 	<maintainer type="person">
 		<email>gentoo@aisha.cc</email>
 		<name>Aisha Tammy</name>
-	</maintainer>	
+	</maintainer>
 	<maintainer type="project">
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ebiggers/libdeflate</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-cpp/Fastor/metadata.xml
+++ b/dev-cpp/Fastor/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">romeric/Fastor</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-cpp/highwayhash/metadata.xml
+++ b/dev-cpp/highwayhash/metadata.xml
@@ -5,4 +5,7 @@
 		<email>junghans@gentoo.org</email>
 		<name>Christoph Junghans</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">google/highwayhash</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-cpp/xor_singleheader/metadata.xml
+++ b/dev-cpp/xor_singleheader/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">FastFilter/xor_singleheader</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-lang/yaggo/metadata.xml
+++ b/dev-lang/yaggo/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">gmarcais/yaggo</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-libs/simclist/metadata.xml
+++ b/dev-libs/simclist/metadata.xml
@@ -15,4 +15,7 @@
 		<flag name="dump">Disable building of dump and restore functionalities</flag>
 		<flag name="hash">Allow list_hash() to work exclusively on memory locations</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">mij/simclist</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-libs/tut/metadata.xml
+++ b/dev-libs/tut/metadata.xml
@@ -1,8 +1,11 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="project">
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">mrzechonek/tut-framework</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-ml/lacaml/metadata.xml
+++ b/dev-ml/lacaml/metadata.xml
@@ -15,5 +15,6 @@
 	</longdescription>
 	<upstream>
 		<remote-id type="bitbucket">mmottl/lacaml</remote-id>
+		<remote-id type="github">mmottl/lacaml</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/asciitree/metadata.xml
+++ b/dev-python/asciitree/metadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">mbr/asciitree</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/fiat/metadata.xml
+++ b/dev-python/fiat/metadata.xml
@@ -17,5 +17,6 @@ support Hermite and nonconforming elements.
 </longdescription>
 	<upstream>
 		<remote-id type="bitbucket">fenics-project/fiat</remote-id>
+		<remote-id type="github">FEniCS/fiat</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/hopcroftkarp/metadata.xml
+++ b/dev-python/hopcroftkarp/metadata.xml
@@ -1,12 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <maintainer type="person">
-        <email>gentoo@aisha.cc</email>
-        <name>Aisha Tammy</name>
-    </maintainer>
-    <maintainer type="project">
-        <email>sci@gentoo.org</email>
-        <name>Gentoo Science Project</name>
-    </maintainer>
+	<maintainer type="person">
+		<email>gentoo@aisha.cc</email>
+		<name>Aisha Tammy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>sci@gentoo.org</email>
+		<name>Gentoo Science Project</name>
+	</maintainer>
+	<upstream>
+		<remote-id type="github">sofiatolaosebikan/hopcroftkarp</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/json_tricks/metadata.xml
+++ b/dev-python/json_tricks/metadata.xml
@@ -21,6 +21,6 @@
 	</longdescription>
 	<upstream>
 		<remote-id type="pypi">json-tricks</remote-id>
+		<remote-id type="github">mverleg/pyjson_tricks</remote-id>
 	</upstream>
 </pkgmetadata>
-

--- a/dev-python/kmapper/metadata.xml
+++ b/dev-python/kmapper/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">scikit-tda/kepler-mapper</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/meshpy/metadata.xml
+++ b/dev-python/meshpy/metadata.xml
@@ -15,5 +15,6 @@ Hang Si. Both are included in the package in slightly modified versions.
 </longdescription>
 	<upstream>
 		<remote-id type="pypi">MeshPy</remote-id>
+		<remote-id type="github">inducer/meshpy</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/numba/metadata.xml
+++ b/dev-python/numba/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">numba/numba</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/python-gantt/metadata.xml
+++ b/dev-python/python-gantt/metadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
@@ -13,4 +13,7 @@
 		Python-Gantt makes it possible to easily draw gantt charts from Python
 		and export outputs as scalable vector graphics (SVG).
 	</longdescription>
+	<upstream>
+		<remote-id type="github">stefanSchinkel/gantt</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/pyvote/metadata.xml
+++ b/dev-python/pyvote/metadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
@@ -16,4 +16,7 @@
 		(or normal) probability density function for outcomes, or a fixed
 		outcome probability.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">TheChymera/pyvote</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/pyzo/metadata.xml
+++ b/dev-python/pyzo/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">pyzo/pyzo</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/repsep_utils/metadata.xml
+++ b/dev-python/repsep_utils/metadata.xml
@@ -1,15 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-  <maintainer type="person">
-    <email>chr@chymera.eu</email>
-    <name>Horea Christian</name>
-  </maintainer>
-  <longdescription lang="en">
+	<maintainer type="person">
+		<email>chr@chymera.eu</email>
+		<name>Horea Christian</name>
+	</maintainer>
+	<longdescription lang="en">
     Utilities for compiling and developing RepSeP-style articles, such as the
     reference implementation. The package contains generic boilerplate code for
     PythonTeX-interaction, as used by all RepSeP-style articles, as well as an
     executable file allowing single-script execution for development and
     debugging purposes.
   </longdescription>
+	<upstream>
+		<remote-id type="github">TheChymera/repsep_utils</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/snakemake/metadata.xml
+++ b/dev-python/snakemake/metadata.xml
@@ -8,5 +8,6 @@
 	<upstream>
 		<remote-id type="bitbucket">johanneskoester/snakemake</remote-id>
 		<remote-id type="pypi">snakemake</remote-id>
+		<remote-id type="github">snakemake/snakemake</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-python/sphinx-argparse/metadata.xml
+++ b/dev-python/sphinx-argparse/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ashb/sphinx-argparse</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-python/ufl/metadata.xml
+++ b/dev-python/ufl/metadata.xml
@@ -14,5 +14,6 @@ mathematical notation.
 </longdescription>
 	<upstream>
 		<remote-id type="bitbucket">fenics-project/ufl</remote-id>
+		<remote-id type="github">FEniCS/ufl</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/dev-util/makefile2graph/metadata.xml
+++ b/dev-util/makefile2graph/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">lindenb/makefile2graph</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/dev-util/plog/metadata.xml
+++ b/dev-util/plog/metadata.xml
@@ -4,4 +4,7 @@
 	<maintainer type="person">
 		<email>heroxbd@gentoo.org</email>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">SergiusTheBest/plog</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-libs/libgfx/metadata.xml
+++ b/media-libs/libgfx/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">mjgarland/libgfx</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/media-libs/mmg/metadata.xml
+++ b/media-libs/mmg/metadata.xml
@@ -13,4 +13,7 @@
 		<flag name="scotch">Use SCOTCH TOOL for renumbering</flag>
 		<flag name="vtk">Use VTK I/O</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">MmgTools/mmg</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/BRAKER/metadata.xml
+++ b/sci-biology/BRAKER/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">Gaius-Augustus/BRAKER</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/GAL/metadata.xml
+++ b/sci-biology/GAL/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">The-Sequence-Ontology/GAL</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/RAILS/metadata.xml
+++ b/sci-biology/RAILS/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bcgsc/RAILS</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/VelvetOptimiser/metadata.xml
+++ b/sci-biology/VelvetOptimiser/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">tseemann/VelvetOptimiser</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/afni/metadata.xml
+++ b/sci-biology/afni/metadata.xml
@@ -13,4 +13,7 @@
 		Analysis of Functional NeuroImages (AFNI) is an open-source environment for processing and displaying 
 		functional MRI data—a technique for mapping human brain activity.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">afni/afni</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/angsd/metadata.xml
+++ b/sci-biology/angsd/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ANGSD/angsd</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/ants/metadata.xml
+++ b/sci-biology/ants/metadata.xml
@@ -21,4 +21,7 @@
 	<use>
 		<flag name="vtk">Optional support for a number of surface enabled tools (via sci-libs/vtk).</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">ANTsX/ANTs</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/bamql/metadata.xml
+++ b/sci-biology/bamql/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">BoutrosLaboratory/bamql</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/barrnap/metadata.xml
+++ b/sci-biology/barrnap/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">tseemann/barrnap</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/bismark/metadata.xml
+++ b/sci-biology/bismark/metadata.xml
@@ -20,4 +20,7 @@ and gapped alignments; (4) Alignment seed length, number of mismatches etc. are
 adjustable; (5) Output discriminates between cytosine methylation in CpG, CHG
 and CHH context.
 </longdescription>
+	<upstream>
+		<remote-id type="github">FelixKrueger/Bismark</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/btl_bloomfilter/metadata.xml
+++ b/sci-biology/btl_bloomfilter/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bcgsc/btl_bloomfilter</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/bx-python/metadata.xml
+++ b/sci-biology/bx-python/metadata.xml
@@ -12,5 +12,6 @@
 	<upstream>
 		<remote-id type="bitbucket">james_taylor/bx-python</remote-id>
 		<remote-id type="pypi">bx-python</remote-id>
+		<remote-id type="github">bxlab/bx-python</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-biology/dcm2niix/metadata.xml
+++ b/sci-biology/dcm2niix/metadata.xml
@@ -19,4 +19,7 @@
 		format to the NIfTI format. ICOM provides many ways to store/compress
 		image data, known as transfer syntaxes.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">rordenlab/dcm2niix</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/dcmstack/metadata.xml
+++ b/sci-biology/dcmstack/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">moloney/dcmstack</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/diamond/metadata.xml
+++ b/sci-biology/diamond/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bbuchfink/diamond</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/fastqc/metadata.xml
+++ b/sci-biology/fastqc/metadata.xml
@@ -13,4 +13,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">s-andrews/FastQC</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/ffindex/metadata.xml
+++ b/sci-biology/ffindex/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ahcm/ffindex</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/longstitch/metadata.xml
+++ b/sci-biology/longstitch/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bcgsc/LongStitch</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/mreps/metadata.xml
+++ b/sci-biology/mreps/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">gregorykucherov/mreps</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/nextclip/metadata.xml
+++ b/sci-biology/nextclip/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">richardmleggett/nextclip</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/ngs/metadata.xml
+++ b/sci-biology/ngs/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ncbi/ngs</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/ntCard/metadata.xml
+++ b/sci-biology/ntCard/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bcgsc/ntCard</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/prokka/metadata.xml
+++ b/sci-biology/prokka/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">tseemann/prokka</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/pyfaidx/metadata.xml
+++ b/sci-biology/pyfaidx/metadata.xml
@@ -11,5 +11,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">pyfaidx</remote-id>
+		<remote-id type="github">mdshw5/pyfaidx</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-biology/quicktree/metadata.xml
+++ b/sci-biology/quicktree/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">khowe/quicktree</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/rtg-tools/metadata.xml
+++ b/sci-biology/rtg-tools/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">RealTimeGenomics/rtg-tools</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/seqtk/metadata.xml
+++ b/sci-biology/seqtk/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">lh3/seqtk</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/spm/metadata.xml
+++ b/sci-biology/spm/metadata.xml
@@ -5,4 +5,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">spm/spm12</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/trans-abyss/metadata.xml
+++ b/sci-biology/trans-abyss/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">bcgsc/transabyss</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/trim_galore/metadata.xml
+++ b/sci-biology/trim_galore/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">FelixKrueger/TrimGalore</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-biology/ugene/metadata.xml
+++ b/sci-biology/ugene/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">ugeneunipro/ugene</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-chemistry/erkale/metadata.xml
+++ b/sci-chemistry/erkale/metadata.xml
@@ -18,4 +18,7 @@ ground-state electron momentum densities and Compton profiles, and core
 (x-ray absorption and x-ray Raman scattering) and valence electron
 excitation spectra of atoms and molecules.
 </longdescription>
+	<upstream>
+		<remote-id type="github">susilehtola/erkale</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-chemistry/relion/metadata.xml
+++ b/sci-chemistry/relion/metadata.xml
@@ -12,4 +12,7 @@
 	<use>
 		<flag name="gui">Enable relion gui</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">3dem/relion</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-libs/HDF5Plugin-Zstandard/metadata.xml
+++ b/sci-libs/HDF5Plugin-Zstandard/metadata.xml
@@ -5,4 +5,7 @@
 		<email>xgreenlandforwyy@gmail.com</email>
 		<name>Yiyang Wu</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">aparamon/HDF5Plugin-Zstandard</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-libs/fast5/metadata.xml
+++ b/sci-libs/fast5/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci-biology@gentoo.org</email>
 		<name>Gentoo Biology Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">mateidavid/fast5</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-libs/nipy/metadata.xml
+++ b/sci-libs/nipy/metadata.xml
@@ -11,5 +11,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">nipy</remote-id>
+		<remote-id type="github">nipy/nipy</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-libs/scikits_video/metadata.xml
+++ b/sci-libs/scikits_video/metadata.xml
@@ -14,5 +14,6 @@
 	</longdescription>
 	<upstream>
 		<remote-id type="pypi">scikit-video</remote-id>
+		<remote-id type="github">scikit-video/scikit-video</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-libs/spyking-circus/metadata.xml
+++ b/sci-libs/spyking-circus/metadata.xml
@@ -16,4 +16,7 @@
 		on datasets coming from in vitro retina with 252 electrodes MEA, from in
 		vivo hippocampus with tetrodes, and in vivo and in vitro cortex data.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">spyking-circus/spyking-circus</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-libs/torchvision/metadata.xml
+++ b/sci-libs/torchvision/metadata.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <maintainer type="person">
-        <email>jpizarrocallejas@gmail.com</email>
-        <name>Jorge Pizarro Callejas</name>
-    </maintainer>
-    <use>
-        <flag name="cuda">Enable CUDA support if enabled in PyTorch</flag>
-    </use>
+	<maintainer type="person">
+		<email>jpizarrocallejas@gmail.com</email>
+		<name>Jorge Pizarro Callejas</name>
+	</maintainer>
+	<use>
+		<flag name="cuda">Enable CUDA support if enabled in PyTorch</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">pytorch/vision</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-libs/vxl/metadata.xml
+++ b/sci-libs/vxl/metadata.xml
@@ -13,5 +13,6 @@ written in ANSI/ISO C++ and is designed to be portable over many platforms.
 </longdescription>
 	<upstream>
 		<remote-id type="sourceforge">vxl</remote-id>
+		<remote-id type="github">vxl/vxl</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-libs/wannier90/metadata.xml
+++ b/sci-libs/wannier90/metadata.xml
@@ -18,5 +18,6 @@
 	<upstream>
 		<doc>http://www.wannier.org/</doc>
 		<remote-id type="launchpad">wannier90</remote-id>
+		<remote-id type="github">wannier-developers/wannier90</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-mathematics/freefem++/metadata.xml
+++ b/sci-mathematics/freefem++/metadata.xml
@@ -10,4 +10,7 @@ FreeFem++ is an implementation of a language dedicated to the finite
 element method. It enables you to solve Partial Differential Equations
 (PDE) easily.
 </longdescription>
+	<upstream>
+		<remote-id type="github">FreeFem/FreeFem-sources</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-mathematics/pulp/metadata.xml
+++ b/sci-mathematics/pulp/metadata.xml
@@ -7,5 +7,6 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="pypi">PuLP</remote-id>
+		<remote-id type="github">coin-or/pulp</remote-id>
 	</upstream>
 </pkgmetadata>

--- a/sci-mathematics/ripser/metadata.xml
+++ b/sci-mathematics/ripser/metadata.xml
@@ -1,16 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
-    <maintainer type="person">
-        <email>gentoo@aisha.cc</email>
-        <name>Aisha Tammy</name>
-    </maintainer>
-    <maintainer type="project">
-        <email>sci@gentoo.org</email>
-        <name>Gentoo Science Project</name>
-    </maintainer>
-    <use>
-      <flag name="progress">print progress of calculations in console</flag>
-      <flag name="sparsehash">use google sparsehash for storage</flag>
-    </use>
+	<maintainer type="person">
+		<email>gentoo@aisha.cc</email>
+		<name>Aisha Tammy</name>
+	</maintainer>
+	<maintainer type="project">
+		<email>sci@gentoo.org</email>
+		<name>Gentoo Science Project</name>
+	</maintainer>
+	<use>
+		<flag name="progress">print progress of calculations in console</flag>
+		<flag name="sparsehash">use google sparsehash for storage</flag>
+	</use>
+	<upstream>
+		<remote-id type="github">Ripser/ripser</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-misc/elmer-fem/metadata.xml
+++ b/sci-misc/elmer-fem/metadata.xml
@@ -7,6 +7,7 @@
 	</maintainer>
 	<upstream>
 		<remote-id type="sourceforge">svn</remote-id>
+		<remote-id type="github">ElmerCSC/elmerfem</remote-id>
 	</upstream>
 	<use>
 		<flag name="gui">Build the ElmerGUI</flag>

--- a/sci-physics/feyncalc/metadata.xml
+++ b/sci-physics/feyncalc/metadata.xml
@@ -19,4 +19,7 @@
 	<use>
 		<flag name="FCtraditionalFormOutput">Use TraditionalForm typesetting.</flag>
 	</use>
+	<upstream>
+		<remote-id type="github">FeynCalc/feyncalc</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-physics/qcdloop/metadata.xml
+++ b/sci-physics/qcdloop/metadata.xml
@@ -12,4 +12,7 @@
 	<longdescription lang="en">
 	QCDLoop is a library of one-loop scalar Feynman integrals, evaluated close to four dimensions. First documented in arXiv:0712.1851 and recently in arXiv:1605.03181.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">scarrazza/qcdloop</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-visualization/clip/metadata.xml
+++ b/sci-visualization/clip/metadata.xml
@@ -9,4 +9,7 @@
 		<email>sci@gentoo.org</email>
 		<name>Gentoo Science Project</name>
 	</maintainer>
+	<upstream>
+		<remote-id type="github">asmuth/clip</remote-id>
+	</upstream>
 </pkgmetadata>

--- a/sci-visualization/fsleyes/metadata.xml
+++ b/sci-visualization/fsleyes/metadata.xml
@@ -1,4 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE pkgmetadata SYSTEM "http://www.gentoo.org/dtd/metadata.dtd">
 <pkgmetadata>
 	<maintainer type="person">
@@ -15,4 +15,7 @@
 		to FSLView, and aims to improve and expand upon this functionality in many
 		ways.
 	</longdescription>
+	<upstream>
+		<remote-id type="github">pauldmccarthy/fsleyes</remote-id>
+	</upstream>
 </pkgmetadata>


### PR DESCRIPTION
This is some preparatory work for https://bugs.gentoo.org/881055.

The github repo names were inferred from SRC_URI.