### PR TITLE
Fix compiling error of dev-python/pyarrow

### DIFF
--- a/dev-libs/apache-arrow/apache-arrow-11.0.0.ebuild
+++ b/dev-libs/apache-arrow/apache-arrow-11.0.0.ebuild
@@ -1,11 +1,11 @@
-# Copyright 2021-2022 Gentoo Authors
+# Copyright 2021-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=8
 
 inherit cmake
 
-IUSE="+bzip2 +brotli +csv +lz4 +parquet snappy test +zlib +zstd"
+IUSE="+bzip2 +brotli +csv +json +lz4 +parquet snappy test +zlib +zstd"
 
 DESCRIPTION="A cross-language development platform for in-memory data."
 HOMEPAGE="https://arrow.apache.org/"
@@ -67,6 +67,7 @@ src_configure() {
 		-DARROW_DEPENDENCY_SOURCE=SYSTEM
 		-DARROW_BUILD_STATIC=OFF
 		-DARROW_CSV=$(usex csv ON OFF)
+		-DARROW_JSON=$(usex json ON OFF)
 		-DARROW_DATASET=ON
 		-DARROW_DOC_DIR=share/doc/${PF}
 		-DARROW_JEMALLOC=OFF

--- a/dev-libs/apache-arrow/metadata.xml
+++ b/dev-libs/apache-arrow/metadata.xml
@@ -12,6 +12,7 @@
 	<use>
 		<flag name='brotli'>Enable brotli compression suppor</flag>
 		<flag name='csv'>Enables read/write csv format</flag>
+		<flag name='json'>Enables read/write json format</flag>
 		<flag name='parquet'>Enables read/write parquet data format</flag>
 	</use>
 </pkgmetadata>

--- a/dev-python/pyarrow/pyarrow-11.0.0.ebuild
+++ b/dev-python/pyarrow/pyarrow-11.0.0.ebuild
@@ -24,7 +24,7 @@ RESTRICT="test" # tests seems not working
 BDEPEND="dev-util/cmake"
 RDEPEND="
 	dev-python/numpy[${PYTHON_USEDEP}]
-	~dev-libs/apache-arrow-${PV}[csv,parquet?]
+	~dev-libs/apache-arrow-${PV}[csv,json,parquet?,snappy]
 "
 DEPEND="${RDEPEND}"
 


### PR DESCRIPTION
When merge `dev-python/pyarrow` directly from this repo, it will give an error like `arrow/json/option.h not found` , which is caused by the `-DARROW_JSON` not set for compiling `dev-libs/apache-arrow` . Here I add a flag `json` to let user enable/disable that.

What's more, the `snappy` flag of apache-arrow should be enabled for pyarrow, or it may cause problems like `pyarrow.lib.ArrowNotImplementedError: Support for codec 'snappy' not built` .

This pull request should fix those problems.