### PR TITLE
app-office/visidata: add missing runtime dep

### DIFF
--- a/app-office/visidata/visidata-2.11-r1.ebuild
+++ b/app-office/visidata/visidata-2.11-r1.ebuild
@@ -4,20 +4,25 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{11..11} )
+PYTHON_COMPAT=( python3_{10..11} )
 
 inherit distutils-r1 optfeature
 
-MY_HASH="5ff7883563eeac32fe192c5b2d4290a4e1e91cc2"
 DESCRIPTION="Terminal spreadsheet multitool for discovering and arranging data"
 HOMEPAGE="http://visidata.org"
-SRC_URI="https://github.com/saulpw/visidata/archive/${MY_HASH}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI="https://github.com/saulpw/${PN}/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
+# Tests fail on recent Python:
+# https://github.com/saulpw/visidata/issues/1905
+RESTRICT="test"
 
-RDEPEND="dev-python/python-dateutil[${PYTHON_USEDEP}]"
+RDEPEND="
+	>=dev-python/importlib-metadata-3.6[${PYTHON_USEDEP}]
+	dev-python/python-dateutil[${PYTHON_USEDEP}]
+"
 BDEPEND="
 	test? (
 		dev-python/h5py[${PYTHON_USEDEP}]
@@ -30,8 +35,6 @@ BDEPEND="
 		$(python_gen_impl_dep sqlite)
 	)
 "
-
-S="${WORKDIR}/${PN}-${MY_HASH}"
 
 #distutils_enable_sphinx docs \
 #	dev-python/recommonmark \

--- a/app-office/visidata/visidata-2.11_p20230217-r1.ebuild
+++ b/app-office/visidata/visidata-2.11_p20230217-r1.ebuild
@@ -4,22 +4,23 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_{11..11} )
 
 inherit distutils-r1 optfeature
 
+MY_HASH="5ff7883563eeac32fe192c5b2d4290a4e1e91cc2"
 DESCRIPTION="Terminal spreadsheet multitool for discovering and arranging data"
 HOMEPAGE="http://visidata.org"
-SRC_URI="https://github.com/saulpw/${PN}/archive/v${PV}.tar.gz -> ${P}.gh.tar.gz"
+SRC_URI="https://github.com/saulpw/visidata/archive/${MY_HASH}.tar.gz -> ${P}.gh.tar.gz"
 
 LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86"
-# Tests fail on recent Python:
-# https://github.com/saulpw/visidata/issues/1905
-RESTRICT="test"
 
-RDEPEND="dev-python/python-dateutil[${PYTHON_USEDEP}]"
+RDEPEND="
+	>=dev-python/importlib-metadata-3.6[${PYTHON_USEDEP}]
+	dev-python/python-dateutil[${PYTHON_USEDEP}]
+"
 BDEPEND="
 	test? (
 		dev-python/h5py[${PYTHON_USEDEP}]
@@ -32,6 +33,8 @@ BDEPEND="
 		$(python_gen_impl_dep sqlite)
 	)
 "
+
+S="${WORKDIR}/${PN}-${MY_HASH}"
 
 #distutils_enable_sphinx docs \
 #	dev-python/recommonmark \


### PR DESCRIPTION
Hi, visidata depends on importlib_metadata since v2.10: https://github.com/saulpw/visidata/commit/851cc5e5b3552beb4d818271ea1febe9761ecd61
```
% visidata
Traceback (most recent call last):
  File "/usr/lib/python-exec/python3.11/visidata", line 8, in <module>
    sys.exit(vd_cli())
             ^^^^^^^^
  File "/usr/lib/python3.11/site-packages/visidata/main.py", line 367, in vd_cli
    rc = main_vd()
         ^^^^^^^^^
  File "/usr/lib/python3.11/site-packages/visidata/main.py", line 262, in main_vd
    vd.loadConfigAndPlugins(args)
  File "/usr/lib/python3.11/site-packages/visidata/settings.py", line 387, in loadConfigAndPlugins
    from importlib_metadata import entry_points  # a backport which supports < 3.8 https://github.com/pypa/twine/pull/732
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'importlib_metadata'
```