### PR TITLE
sci-mathematics/cipi: Fix boost linking

### DIFF
--- a/sci-mathematics/cipi/cipi-1.0-r1.ebuild
+++ b/sci-mathematics/cipi/cipi-1.0-r1.ebuild
@@ -1,7 +1,7 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
 
 inherit cmake flag-o-matic
 

--- a/sci-mathematics/cipi/cipi-1.0-r1.ebuild
+++ b/sci-mathematics/cipi/cipi-1.0-r1.ebuild
@@ -16,7 +16,7 @@ KEYWORDS="~amd64 ~x86"
 IUSE="doc"
 
 DEPEND="
-	dev-libs/boost
+	dev-libs/boost:=
 	doc? ( virtual/latex-base )"
 RDEPEND="${DEPEND}"
 

--- a/sci-mathematics/cipi/cipi-1.0-r1.ebuild
+++ b/sci-mathematics/cipi/cipi-1.0-r1.ebuild
@@ -42,9 +42,9 @@ src_configure() {
 }
 
 pkg_postinst() {
-	echo ""
+	elog
 	elog "The sample PARAM file has been installed to /usr/share/${PN}-${PV}"
-	echo ""
+	elog
 	if use doc; then
 		elog "A pdf manual has been installed to /usr/share/${PN}-${PV}"
 	fi

--- a/sci-mathematics/cipi/cipi-1.0-r1.ebuild
+++ b/sci-mathematics/cipi/cipi-1.0-r1.ebuild
@@ -1,0 +1,51 @@
+# Copyright 1999-2021 Gentoo Authors
+# Distributed under the terms of the GNU General Public License v2
+
+EAPI=7
+
+inherit cmake flag-o-matic
+
+DESCRIPTION="Computing information projections iteratively"
+HOMEPAGE="https://github.com/tom111/cipi"
+SRC_URI="https://github.com/tom111/cipi/archive/${PV}.tar.gz -> ${P}.tar.gz"
+
+LICENSE="GPL-3"
+SLOT="0"
+KEYWORDS="~amd64 ~x86"
+
+IUSE="doc"
+
+DEPEND="
+	dev-libs/boost
+	doc? ( virtual/latex-base )"
+RDEPEND="${DEPEND}"
+
+DOCS="AUTHORS README"
+
+CMAKE_IN_SOURCE_BUILD="yes"
+
+PATCHES=(
+	"${FILESDIR}/${P}-boost.patch"
+)
+
+src_prepare() {
+	cmake_src_prepare
+	append-ldflags -Wl,--copy-dt-needed-entries
+}
+
+src_configure() {
+	mycmakeargs=(
+		-DENABLE_DOC=$(usex doc ON OFF)
+	)
+
+	cmake_src_configure
+}
+
+pkg_postinst() {
+	echo ""
+	elog "The sample PARAM file has been installed to /usr/share/${PN}-${PV}"
+	echo ""
+	if use doc; then
+		elog "A pdf manual has been installed to /usr/share/${PN}-${PV}"
+	fi
+}

--- a/sci-mathematics/cipi/files/cipi-1.0-boost.patch
+++ b/sci-mathematics/cipi/files/cipi-1.0-boost.patch
@@ -1,0 +1,11 @@
+--- a/src/CMakeLists.txt	2024-02-16 21:36:58.808186061 +0100
++++ b/src/CMakeLists.txt	2024-02-16 21:36:55.288131610 +0100
+@@ -8,7 +8,7 @@
+   Message("Boost found" ${Boost_LIBRARY_DIR})
+   INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIR})
+   #MESSAGE("Boost was found" ${Boost_INCLUDE_DIR})
+-  TARGET_LINK_LIBRARIES (cipi boost_thread-mt)
++  TARGET_LINK_LIBRARIES (cipi boost_thread)
+ ENDIF (Boost_FOUND)
+ 
+ INSTALL(PROGRAMS cipi DESTINATION bin)


### PR DESCRIPTION
Don't know if this used or maintained I PRed the patch anyway: https://github.com/tom111/cipi/pull/1