### PR TITLE
dev-python/nptyping: update maintainers

### DIFF
--- a/dev-python/nptyping/metadata.xml
+++ b/dev-python/nptyping/metadata.xml
@@ -9,6 +9,7 @@
 		<email>gentoo@chymera.eu</email>
 		<name>Horea Christian</name>
 	</maintainer>
+	<upstream>
 		<remote-id type="pypi">nptyping</remote-id>
 		<remote-id type="github">ramonhagenaars/nptyping</remote-id>
 	</upstream>


### PR DESCRIPTION
Repology updates broke by this. See https://github.com/repology/repology-updater/commit/688fc91d1092e3c7b7b5c79bd03935bb54e872b1

I am surprissed that `pkgcheck scan` reports `PkgBadlyFormedXml` only as a warning. Should we promote it to an error in the CI?