### PR TITLE
sci-physics/cernlib: Fix test failures

### DIFF
--- a/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
+++ b/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
@@ -1,7 +1,7 @@
 EAPI=8
 
 CMAKE_MAKEFILE_GENERATOR="emake"
-inherit cmake fortran-2
+inherit cmake fortran-2 flag-o-matic
 
 DESCRIPTION="CERN program library for High Energy Physics"
 HOMEPAGE="https://cernlib.web.cern.ch/cernlib/"
@@ -16,7 +16,8 @@ LICENSE="
 "
 SLOT="0"
 KEYWORDS="~amd64"
-IUSE="+free"
+# static-libs as default since otherwise test fail...
+IUSE="+free +static-libs"
 RESTRICT="mirror"
 
 RDEPEND="
@@ -59,6 +60,11 @@ src_configure() {
 	# docs follow rpm like spliting into packages cernlib, cernlib-devel, etc.
 	# we move them into a folder that agrees with gentoo doc structure.
 	sed -i "s#/doc/#/doc/${PF}/#g" CMakeLists.txt || die
+	# with -O2 some tests fail
+	append-flags -O0
+	local mycmakeargs=(
+		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
+	)
 	cmake_src_configure
 }
 

--- a/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
+++ b/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
@@ -61,7 +61,8 @@ src_configure() {
 	# we move them into a folder that agrees with gentoo doc structure.
 	sed -i "s#/doc/#/doc/${PF}/#g" CMakeLists.txt || die
 	# with -O2 some tests fail
-	filter-flags -O2 -O3 -Os
+	# let upstream decide on optimization (-O0) since code is fragile
+	filter-flags -O1 -O2 -O3 -Os
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 	)

--- a/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
+++ b/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
@@ -61,7 +61,7 @@ src_configure() {
 	# we move them into a folder that agrees with gentoo doc structure.
 	sed -i "s#/doc/#/doc/${PF}/#g" CMakeLists.txt || die
 	# with -O2 some tests fail
-	append-flags -O0
+	filter-flags -O2 -O3 -Os
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 	)

--- a/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
+++ b/sci-physics/cernlib/cernlib-2023.10.31.0-r2.ebuild
@@ -62,7 +62,7 @@ src_configure() {
 	sed -i "s#/doc/#/doc/${PF}/#g" CMakeLists.txt || die
 	# with -O2 some tests fail
 	# let upstream decide on optimization (-O0) since code is fragile
-	filter-flags -O1 -O2 -O3 -Os
+	filter-flags -O1 -O2 -O3 -Os -Oz -Og -Ofast
 	local mycmakeargs=(
 		-DBUILD_SHARED_LIBS=$(usex static-libs OFF ON)
 	)


### PR DESCRIPTION
Login required issue link: https://gitlab.cern.ch/DPHEP/cernlib/cernlib/-/issues/43

> APN-Pucky: Both 2024.04.15.0-beta and 2023.10.31.0 pass without failures for me now, but only with -DBUILD_SHARED_LIBS=OFF and -O0. Going to -O2 fails some testzebfzs or going to shared fails the testkernnumtest.