### PR TITLE
sci-biology/imagej:  ant-core deprecated

### DIFF
--- a/sci-biology/imagej/imagej-1.54i-r1.ebuild
+++ b/sci-biology/imagej/imagej-1.54i-r1.ebuild
@@ -50,7 +50,6 @@ DEPEND="
 "
 
 BDEPEND="
-	dev-java/ant-core
 	app-arch/unzip
 "
 

--- a/sci-biology/imagej/imagej-9999.ebuild
+++ b/sci-biology/imagej/imagej-9999.ebuild
@@ -50,7 +50,6 @@ DEPEND="
 "
 
 BDEPEND="
-	dev-java/ant-core
 	app-arch/unzip
 "
 


### PR DESCRIPTION
Signed-off-by: IAHMCOL <IAHMCOL@thejabberwocky.net>

This commit removes dev-java/ant-core from dependencies This has been deprecated, and it gets automatically used with ant2

Latest updates had depclean  dev-java/ant-core, and the packages still builds after dependency removal

see:
https://packages.gentoo.org/packages/dev-java/ant-core