### PR TITLE
sci-libs/starparse: switch to guile eclass

### DIFF
--- a/sci-libs/starparse/starparse-0.9-r1.ebuild
+++ b/sci-libs/starparse/starparse-0.9-r1.ebuild
@@ -1,7 +1,10 @@
 # Copyright 1999-2021 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=7
+EAPI=8
+
+GUILE_COMPAT=( 1-8 )
+inherit guile-single
 
 DESCRIPTION="Library for parsing NMR star files (peak-list format) and CIF files"
 HOMEPAGE="http://burrow-owl.sourceforge.net/"
@@ -14,12 +17,32 @@ KEYWORDS="~amd64"
 IUSE="guile test"
 RESTRICT="!test? ( test )"
 
-REQUIRED_USE="test? ( guile )"
+REQUIRED_USE="test? ( guile ) guile? ( ${GUILE_REQUIRED_USE} )"
 
-RDEPEND="guile? ( dev-scheme/guile:12 )"
+RDEPEND="guile? ( ${GUILE_DEPS} )"
 DEPEND="${RDEPEND}"
 BDEPEND="virtual/pkgconfig"
 
+src_prepare() {
+	default
+	if use guile; then
+		guile-single_src_prepare
+	fi
+}
+
+pkg_setup() {
+	if use guile; then
+		guile-single_pkg_setup
+	fi
+}
+
 src_configure() {
 	econf $(use_enable guile)
+}
+
+src_install() {
+	default
+	if use guile; then
+		guile_unstrip_ccache
+	fi
 }


### PR DESCRIPTION
- old upstream with no updates
- no revdeps