### PR TITLE
*/*: Remove py3.10 (per sphinx-8.2)

### DIFF
--- a/dev-python/ccdproc/ccdproc-2.3.0.ebuild
+++ b/dev-python/ccdproc/ccdproc-2.3.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Astropy affiliated package for reducing optical/IR CCD data"

--- a/dev-python/fslpy/fslpy-3.10.0.ebuild
+++ b/dev-python/fslpy/fslpy-3.10.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 virtualx
 

--- a/dev-python/gffpandas/gffpandas-1.2.0.ebuild
+++ b/dev-python/gffpandas/gffpandas-1.2.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/dev-python/heudiconv/heudiconv-0.13.0.ebuild
+++ b/dev-python/heudiconv/heudiconv-0.13.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Flexible DICOM conversion to structured directory layouts"

--- a/dev-python/heudiconv/heudiconv-1.0.0.ebuild
+++ b/dev-python/heudiconv/heudiconv-1.0.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Flexible DICOM conversion to structured directory layouts"

--- a/dev-python/reproject/reproject-0.8.ebuild
+++ b/dev-python/reproject/reproject-0.8.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 inherit distutils-r1 pypi
 
 DESCRIPTION="Reproject astronomical images"

--- a/dev-python/sphinx-astropy/sphinx-astropy-1.8.0.ebuild
+++ b/dev-python/sphinx-astropy/sphinx-astropy-1.8.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 PYPI_NO_NORMALIZE=1
 

--- a/dev-python/texext/texext-0.6.7.ebuild
+++ b/dev-python/texext/texext-0.6.7.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1
 

--- a/sci-biology/brkraw/brkraw-0.3.11.ebuild
+++ b/sci-biology/brkraw/brkraw-0.3.11.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 DISTUTILS_USE_PEP517=setuptools
 

--- a/sci-biology/bruker2nifti/bruker2nifti-1.0.4.ebuild
+++ b/sci-biology/bruker2nifti/bruker2nifti-1.0.4.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_SETUPTOOLS="rdepend"
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-biology/dcmstack/dcmstack-0.9.ebuild
+++ b/sci-biology/dcmstack/dcmstack-0.9.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-biology/dipy/dipy-1.1.1.ebuild
+++ b/sci-biology/dipy/dipy-1.1.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-biology/nilearn/nilearn-0.8.1.ebuild
+++ b/sci-biology/nilearn/nilearn-0.8.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-biology/nilearn/nilearn-0.9.1.ebuild
+++ b/sci-biology/nilearn/nilearn-0.9.1.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-biology/nitime/nitime-0.10.2.ebuild
+++ b/sci-biology/nitime/nitime-0.10.2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1 pypi
 

--- a/sci-biology/nitime/nitime-0.9.ebuild
+++ b/sci-biology/nitime/nitime-0.9.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1 pypi virtualx
 

--- a/sci-biology/nitime/nitime-9999.ebuild
+++ b/sci-biology/nitime/nitime-9999.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1 git-r3
 

--- a/sci-libs/nibabel/nibabel-5.0.0.ebuild
+++ b/sci-libs/nibabel/nibabel-5.0.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=hatchling
 
 inherit distutils-r1

--- a/sci-libs/nibabel/nibabel-5.1.0.ebuild
+++ b/sci-libs/nibabel/nibabel-5.1.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=hatchling
 
 inherit distutils-r1

--- a/sci-libs/nipy/nipy-0.6.0.ebuild
+++ b/sci-libs/nipy/nipy-0.6.0.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=meson-python
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_EXT=1
 
 inherit distutils-r1

--- a/sci-libs/nipype/nipype-1.8.4-r1.ebuild
+++ b/sci-libs/nipype/nipype-1.8.4-r1.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 PYTHON_REQ_USE="threads(+),sqlite"
 
 inherit distutils-r1

--- a/sci-libs/nipype/nipype-1.8.4-r2.ebuild
+++ b/sci-libs/nipype/nipype-1.8.4-r2.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 PYTHON_REQ_USE="threads(+),sqlite"
 
 inherit distutils-r1

--- a/sci-libs/nipype/nipype-1.8.6.ebuild
+++ b/sci-libs/nipype/nipype-1.8.6.ebuild
@@ -4,7 +4,7 @@
 EAPI=8
 
 DISTUTILS_USE_PEP517=setuptools
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 PYTHON_REQ_USE="threads(+),sqlite"
 
 inherit distutils-r1

--- a/sci-libs/pybids/pybids-0.10.2.ebuild
+++ b/sci-libs/pybids/pybids-0.10.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-libs/pybids/pybids-0.12.4.ebuild
+++ b/sci-libs/pybids/pybids-0.12.4.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_SETUPTOOLS=rdepend
 
 inherit distutils-r1

--- a/sci-libs/pybids/pybids-0.6.5.ebuild
+++ b/sci-libs/pybids/pybids-0.6.5.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_{10..11} )
+PYTHON_COMPAT=( python3_11 )
 
 inherit distutils-r1
 

--- a/sci-visualization/fsleyes-props/fsleyes-props-1.8.2.ebuild
+++ b/sci-visualization/fsleyes-props/fsleyes-props-1.8.2.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 virtualx
 

--- a/sci-visualization/fsleyes-widgets/fsleyes-widgets-0.12.3.ebuild
+++ b/sci-visualization/fsleyes-widgets/fsleyes-widgets-0.12.3.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 inherit distutils-r1 virtualx
 

--- a/sci-visualization/fsleyes/fsleyes-1.5.0.ebuild
+++ b/sci-visualization/fsleyes/fsleyes-1.5.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=8
 
-PYTHON_COMPAT=( python3_10 )
+PYTHON_COMPAT=( python3_11 )
 DISTUTILS_USE_PEP517=setuptools
 inherit xdg distutils-r1 desktop virtualx
 


### PR DESCRIPTION
cf. https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=d01c67570325f593985ff8d6051af5fd54793012

I drop 3.10 where needed and if there is only 3.10 I increase it to 3.11 (I tested some, but others are too large for now and or already broken).

Alternatively, they could be masked. I am not sure what is better here.