### PR TITLE
dev-python/llvmlite: fix double EPREFIX

### DIFF
--- a/dev-python/llvmlite/llvmlite-0.44.0.ebuild
+++ b/dev-python/llvmlite/llvmlite-0.44.0.ebuild
@@ -36,6 +36,7 @@ python_test() {
 
 python_install() {
 	distutils-r1_python_install
-	dosym "$(get_llvm_prefix)/$(get_libdir)/libLLVM-${LLVM_SLOT}.so" \
-		"$(python_get_sitedir)/llvmlite/binding/libLLVM-${LLVM_SLOT}.so"
+	# numba compilation fails without this link
+	ln -s "$(get_llvm_prefix)/$(get_libdir)/libLLVM-${LLVM_SLOT}.so" \
+		"${D}/$(python_get_sitedir)/llvmlite/binding/libLLVM-${LLVM_SLOT}.so" || die
 }


### PR DESCRIPTION
as described here: https://github.com/gentoo/sci/pull/1286/files#r1960450387